### PR TITLE
build: allow first build to work

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -1,4 +1,4 @@
-import { defineBuildConfig } from '.'
+import { defineBuildConfig } from './src/types'
 
 export default defineBuildConfig({
   declaration: true,

--- a/build.config.ts
+++ b/build.config.ts
@@ -1,4 +1,4 @@
-import { defineBuildConfig } from './src/types'
+import { defineBuildConfig } from './src'
 
 export default defineBuildConfig({
   declaration: true,


### PR DESCRIPTION
Previous code would work if `unbuild` had previously been built (e.g. with `dist/index.js` in place) - this makes it work in CI/dev.