### PR TITLE
fix: shebang support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-#!/bin/env node
+#!/usr/bin/env node
 import { resolve } from 'pathe'
 import mri from 'mri'
 import { build } from './build'


### PR DESCRIPTION
Edit: Seems like a regression from https://github.com/unjs/unbuild/commit/12ccc15d42a360995280aec057e44cb1bfba0c87.

----

In practice, many tools rely on `/usr/bin/env` as the more commonly recommended way instead of `/bin/env`.

For example, using `nvm` or `fnm`, `/bin/env` won't work, at least on my system.

