### PR TITLE
feat: allow peerDeps as import entry points

### DIFF
--- a/src/validate.ts
+++ b/src/validate.ts
@@ -6,7 +6,7 @@ import { PackageJson } from 'pkg-types'
 import { extractExportFilenames, getpkg } from './utils'
 import { BuildContext } from './types'
 
-export function validateDependencies(ctx: BuildContext) {
+export function validateDependencies (ctx: BuildContext) {
   const usedDependencies = new Set<string>()
   const unusedDependencies = new Set<string>(Object.keys(ctx.pkg.dependencies || {}))
   const implicitDependnecies = new Set<string>()
@@ -37,7 +37,7 @@ export function validateDependencies(ctx: BuildContext) {
   }
 }
 
-export function validatePackage(pkg: PackageJson, rootDir: string) {
+export function validatePackage (pkg: PackageJson, rootDir: string) {
   if (!pkg) { return }
 
   const filenames = new Set([

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -6,7 +6,7 @@ import { PackageJson } from 'pkg-types'
 import { extractExportFilenames, getpkg } from './utils'
 import { BuildContext } from './types'
 
-export function validateDependencies (ctx: BuildContext) {
+export function validateDependencies(ctx: BuildContext) {
   const usedDependencies = new Set<string>()
   const unusedDependencies = new Set<string>(Object.keys(ctx.pkg.dependencies || {}))
   const implicitDependnecies = new Set<string>()
@@ -23,7 +23,8 @@ export function validateDependencies (ctx: BuildContext) {
     if (
       !ctx.options.externals.includes(id) &&
       !id.startsWith('chunks/') &&
-      !ctx.options.dependencies.includes(getpkg(id))
+      !ctx.options.dependencies.includes(getpkg(id)) &&
+      !ctx.options.peerDependencies.includes(getpkg(id))
     ) {
       implicitDependnecies.add(id)
     }
@@ -36,7 +37,7 @@ export function validateDependencies (ctx: BuildContext) {
   }
 }
 
-export function validatePackage (pkg: PackageJson, rootDir: string) {
+export function validatePackage(pkg: PackageJson, rootDir: string) {
   if (!pkg) { return }
 
   const filenames = new Set([

--- a/test/validate.test.ts
+++ b/test/validate.test.ts
@@ -4,7 +4,7 @@ import { expect } from 'chai'
 import consola from 'consola'
 import { join } from 'pathe'
 import { validateDependencies } from '../src/validate'
-import { BuildEntry } from '../src/types.js'
+import { BuildEntry } from '../src/types'
 
 const { validatePackage } = jiti(import.meta.url)('../src/validate') as typeof import('../src/validate')
 

--- a/test/validate.test.ts
+++ b/test/validate.test.ts
@@ -34,8 +34,6 @@ describe('validatePackage', () => {
   })
 })
 
-
-
 describe('validateDependecies', () => {
   it('detects implicit deps', () => {
     const logs: string[] = []
@@ -45,16 +43,16 @@ describe('validateDependecies', () => {
       pkg: {},
       buildEntries: [],
       hooks: [] as any,
-      usedImports: new Set(["pkg-a/core"]),
+      usedImports: new Set(['pkg-a/core']),
       options: {
         externals: [],
-        dependencies: ["react"],
+        dependencies: ['react'],
         peerDependencies: [],
         devDependencies: [],
-        rootDir: ".",
+        rootDir: '.',
         entries: [] as BuildEntry[],
         clean: false,
-        outDir: "dist",
+        outDir: 'dist',
         stub: false,
         alias: {},
         replace: {},
@@ -64,8 +62,8 @@ describe('validateDependecies', () => {
           resolve: false,
           json: false,
           esbuild: false,
-          commonjs: false,
-        },
+          commonjs: false
+        }
       }
     })
 
@@ -80,16 +78,16 @@ describe('validateDependecies', () => {
       pkg: {},
       buildEntries: [],
       hooks: [] as any,
-      usedImports: new Set(["pkg-a/core"]),
+      usedImports: new Set(['pkg-a/core']),
       options: {
         externals: [],
-        dependencies: ["react"],
-        peerDependencies: ["pkg-a"],
+        dependencies: ['react'],
+        peerDependencies: ['pkg-a'],
         devDependencies: [],
-        rootDir: ".",
+        rootDir: '.',
         entries: [] as BuildEntry[],
         clean: false,
-        outDir: "dist",
+        outDir: 'dist',
         stub: false,
         alias: {},
         replace: {},
@@ -99,11 +97,11 @@ describe('validateDependecies', () => {
           resolve: false,
           json: false,
           esbuild: false,
-          commonjs: false,
-        },
+          commonjs: false
+        }
       }
     })
 
-    expect(logs).to.be.empty
+    expect(logs.length).to.eq(0)
   })
 })

--- a/test/validate.test.ts
+++ b/test/validate.test.ts
@@ -3,13 +3,15 @@ import jiti from 'jiti'
 import { expect } from 'chai'
 import consola from 'consola'
 import { join } from 'pathe'
+import { validateDependencies } from '../src/validate'
+import { BuildEntry } from '../src/types.js'
 
 const { validatePackage } = jiti(import.meta.url)('../src/validate') as typeof import('../src/validate')
 
 describe('validatePackage', () => {
   it('detects missing files', () => {
     const logs: string[] = []
-    consola.mock(type => type === 'warn' ? (str: string) => logs.push(str) : () => {})
+    consola.mock(type => type === 'warn' ? (str: string) => logs.push(str) : () => { })
 
     validatePackage({
       main: './dist/test',
@@ -29,5 +31,79 @@ describe('validatePackage', () => {
     for (const file of ['dist/test', 'dist/cli', 'dist/mod', 'runtime']) {
       expect(logs[0]).to.include(file)
     }
+  })
+})
+
+
+
+describe('validateDependecies', () => {
+  it('detects implicit deps', () => {
+    const logs: string[] = []
+    consola.mock(type => type === 'warn' ? (str: string) => logs.push(str) : () => { })
+
+    validateDependencies({
+      pkg: {},
+      buildEntries: [],
+      hooks: [] as any,
+      usedImports: new Set(["pkg-a/core"]),
+      options: {
+        externals: [],
+        dependencies: ["react"],
+        peerDependencies: [],
+        devDependencies: [],
+        rootDir: ".",
+        entries: [] as BuildEntry[],
+        clean: false,
+        outDir: "dist",
+        stub: false,
+        alias: {},
+        replace: {},
+        rollup: {
+          replace: false,
+          alias: false,
+          resolve: false,
+          json: false,
+          esbuild: false,
+          commonjs: false,
+        },
+      }
+    })
+
+    expect(logs[0]).to.include('Potential implicit dependencies found:')
+  })
+
+  it('does not print implicit deps warning for peerDependencies', () => {
+    const logs: string[] = []
+    consola.mock(type => type === 'warn' ? (str: string) => logs.push(str) : () => { })
+
+    validateDependencies({
+      pkg: {},
+      buildEntries: [],
+      hooks: [] as any,
+      usedImports: new Set(["pkg-a/core"]),
+      options: {
+        externals: [],
+        dependencies: ["react"],
+        peerDependencies: ["pkg-a"],
+        devDependencies: [],
+        rootDir: ".",
+        entries: [] as BuildEntry[],
+        clean: false,
+        outDir: "dist",
+        stub: false,
+        alias: {},
+        replace: {},
+        rollup: {
+          replace: false,
+          alias: false,
+          resolve: false,
+          json: false,
+          esbuild: false,
+          commonjs: false,
+        },
+      }
+    })
+
+    expect(logs).to.be.empty
   })
 })


### PR DESCRIPTION
### PR context

Let's say I have `next` in `peerDependencies`, and the following import in my package: 
```
import something from "next/head"
```
When building the package with `unbuild`, it shows a warning: `Potential implicit dependencies found: next/head`, while I think it should be legal to use import from peerDeps.

Let me know if I should make any changes.

---

Thank you for building `unbuild` 🔥