### PR TITLE
Allow external rollup plugins to be applied

### DIFF
--- a/src/builder/rollup.ts
+++ b/src/builder/rollup.ts
@@ -194,8 +194,9 @@ export function getRollupOptions (ctx: BuildContext): RollupOptions {
 
       ctx.options.rollup.cjsBridge && cjsPlugin({}),
 
-      rawPlugin()
+      rawPlugin(),
 
+      ...(ctx.options.rollup.plugins || [])
     ].filter(Boolean)
   } as RollupOptions
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-use-before-define */
 import type { PackageJson } from 'pkg-types'
 import type { Hookable } from 'hookable'
-import type { RollupOptions, RollupBuild } from 'rollup'
+import type { RollupOptions, RollupBuild, Plugin } from 'rollup'
 import type { MkdistOptions } from 'mkdist'
 import type { Options as EsbuildOptions } from 'rollup-plugin-esbuild'
 import type { Schema } from 'untyped'
@@ -51,6 +51,8 @@ export interface RollupBuildOptions {
   esbuild: EsbuildOptions | false
   commonjs: RollupCommonJSOptions | false
   dts: RollupDtsOptions
+  // Other
+  plugins?: (Plugin | null | false | undefined)[]
 }
 
 export interface BuildOptions {


### PR DESCRIPTION
Unbuild provides outstanding defaults for Rollup, and it is highly developer-friendly, but it gets complicated when it comes to a small external change in Rollup. Currently, you would have to hook into the build cycle through an external script and run that script instead of just applying a simple plugin for rollup.

It's a nice feature to provide plugins for Rollup because some codebases require plugins to run other frameworks and extend the ability to transform the code.

Suggested change:
```ts
export default {
    entries: [...],
    plugins: [
        myPlugin({})
    ]
}
```