### PR TITLE
fix(pkg): add types field for exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,13 @@
   "description": "A unified javascript build system",
   "repository": "unjs/unbuild",
   "license": "MIT",
-  "exports": "./dist/index.mjs",
-  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs"
+    }
+  },
+  "types": "./dist/index.d.ts",
   "bin": {
     "unbuild": "./dist/cli.mjs"
   },


### PR DESCRIPTION
Currently, `build.config.ts` does not compat with `"moduleResolution": "Node16"` in tsconfig.

An alternative solution is to support `build.config.mts`

**Before**

![image](https://user-images.githubusercontent.com/18205362/175261655-8fb6fa09-e5c7-404e-aae2-e85a87ccbf60.png)


**After**

![image](https://user-images.githubusercontent.com/18205362/175261457-4e2b5ef7-0516-4133-9c29-6dfaf8f8b3b3.png)
