### PR TITLE
fix: match least-nested files first when inferring entry

### DIFF
--- a/src/auto.ts
+++ b/src/auto.ts
@@ -117,7 +117,7 @@ export function inferEntries (pkg: PackageJson, sourceFiles: string[]): InferEnt
 
     if (isDir) {
       entry.outDir = outputSlug
-        ; (entry as MkdistBuildEntry).format = output.type
+      ;(entry as MkdistBuildEntry).format = output.type
     }
   }
 

--- a/src/auto.ts
+++ b/src/auto.ts
@@ -46,6 +46,9 @@ export const autoPreset = definePreset(() => {
 export function inferEntries (pkg: PackageJson, sourceFiles: string[]): InferEntriesResult {
   const warnings = []
 
+  // Sort files so least-nested files are first
+  sourceFiles.sort((a, b) => a.split('/').length - b.split('/').length)
+
   // Come up with a list of all output files & their formats
   const outputs = extractExportFilenames(pkg.exports)
 
@@ -114,7 +117,7 @@ export function inferEntries (pkg: PackageJson, sourceFiles: string[]): InferEnt
 
     if (isDir) {
       entry.outDir = outputSlug
-      ;(entry as MkdistBuildEntry).format = output.type
+        ; (entry as MkdistBuildEntry).format = output.type
     }
   }
 

--- a/test/auto.test.ts
+++ b/test/auto.test.ts
@@ -12,6 +12,16 @@ describe('inferEntries', () => {
     })
   })
 
+  it('handles nested indexes', () => {
+    const result = inferEntries({ module: 'dist/index.mjs' }, ['src/', 'src/event/index.ts', 'src/index.ts'])
+    expect(result).to.deep.equal({
+      cjs: false,
+      dts: false,
+      entries: [{ input: 'src/index' }],
+      warnings: []
+    })
+  })
+
   it('handles binary outputs', () => {
     expect(inferEntries({ bin: 'dist/cli.cjs' }, ['src/', 'src/cli.ts'])).to.deep.equal({
       cjs: true,


### PR DESCRIPTION
resolves  #107