### PR TITLE
fix: do not throw error on absolute windows paths

### DIFF
--- a/src/builder/rollup.ts
+++ b/src/builder/rollup.ts
@@ -8,7 +8,7 @@ import { nodeResolve } from "@rollup/plugin-node-resolve";
 import alias from "@rollup/plugin-alias";
 import dts from "rollup-plugin-dts";
 import replace from "@rollup/plugin-replace";
-import { resolve, dirname, normalize, extname } from "pathe";
+import { resolve, dirname, normalize, extname, isAbsolute } from "pathe";
 import { resolvePath, resolveModuleExportNames } from "mlly";
 import { getpkg, tryResolve, warn } from "../utils";
 import type { BuildContext } from "../types";
@@ -172,7 +172,7 @@ export function getRollupOptions (ctx: BuildContext): RollupOptions {
       if (isExplicitExternal) {
         return true;
       }
-      if (ctx.options.rollup.inlineDependencies || id[0] === "." || id[0] === "/" || /src[/\\]/.test(id) || id.startsWith(ctx.pkg.name!)) {
+      if (ctx.options.rollup.inlineDependencies || id[0] === "." || isAbsolute(id) || /src[/\\]/.test(id) || id.startsWith(ctx.pkg.name!)) {
         return false;
       }
       if (!isExplicitExternal) {


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Previously when including `package.json` or other local file that is resolved to an absolute path, unbuild would identify this as an external on windows systems, as the absolute path didn't start with `/` but with `C:\`

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
