### PR TITLE
fix: prevent minification of `.d.ts` files

### DIFF
--- a/src/builder/plugins/esbuild.ts
+++ b/src/builder/plugins/esbuild.ts
@@ -96,8 +96,8 @@ export function esbuild (options: Options): Plugin {
       );
     },
 
-    async renderChunk (code) {
-      if (options.minify) {
+    async renderChunk (code, { fileName }) {
+      if (options.minify && !fileName.endsWith('.d.ts')) {
         const result = await transform(code, {
           loader: "js",
           minify: true,


### PR DESCRIPTION
This PR fixes https://github.com/unjs/unbuild/issues/112 by preventing the execution of code modification on d.ts files.