### PR TITLE
fix(rollup): enable `interop: compat` for cjs compatibility

### DIFF
--- a/src/builder/rollup.ts
+++ b/src/builder/rollup.ts
@@ -208,6 +208,7 @@ export function getRollupOptions(ctx: BuildContext): RollupOptions {
           getChunkFilename(chunk, "cjs"),
         format: "cjs",
         exports: "auto",
+        interop: "compat",
         generatedCode: { constBindings: true },
         externalLiveBindings: false,
         freeze: false,


### PR DESCRIPTION

In rollup3, you need to configure  [interop](https://rollupjs.org/configuration-options/#output-interop) to `compat` for cjs to work properly

### Previously

```ts
const esm = require('esm-lib')
console.log(esm)
```

### Currently

```ts
const esm = require('esm-lib')
function _interopDefaultCompat(e) {
	return e && typeof e === 'object' && 'default' in e
		? e
		: { default: e };
}
console.log(_interopDefaultCompat(esm))
```