### PR TITLE
fix(rollup): handle array format for `rollup.alias.entries` option

### DIFF
--- a/src/builder/rollup.ts
+++ b/src/builder/rollup.ts
@@ -268,7 +268,11 @@ export function getRollupOptions(ctx: BuildContext): RollupOptions {
           entries: {
             [ctx.pkg.name!]: ctx.options.rootDir,
             ...ctx.options.alias,
-            ...ctx.options.rollup.alias.entries,
+            ...(Array.isArray(ctx.options.rollup.alias.entries)
+              ? Object.fromEntries(ctx.options.rollup.alias.entries.map(entry => {
+                return [entry.find, entry.replacement]
+              }))
+              : ctx.options.rollup.alias.entries),
           },
         }),
 


### PR DESCRIPTION
rollop alias option from config file like 
```js
rollup: {
  alias: {
      entries: [
        {
          find: '@shared/types',
          replacement: path.resolve(projectRootDir, 'src/shared/types'),
        },
      ],
    }
}
```
entries above wouldn't get the right alias config since `unbuild` does not handle this scene.
This PR is related to https://github.com/unjs/unbuild/issues/221