### PR TITLE
docs: add `types` to default `exports`

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Update `package.json`:
   "type": "module",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     }


### PR DESCRIPTION
This is [required](https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing) for TypeScript to work under `"module": "node16"`, see https://github.com//microsoft/TypeScript/issues/47792.