### PR TITLE
feat(rollup): show size of bundled npm packages in cli output

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -218,7 +218,6 @@ export async function build(
     relative(process.cwd(), resolve(options.outDir, p));
   for (const entry of ctx.buildEntries.filter((e) => !e.chunk)) {
     let totalBytes = entry.bytes || 0;
-    // consola.log(entry);
     for (const chunk of entry.chunks || []) {
       totalBytes += ctx.buildEntries.find((e) => e.path === chunk)?.bytes || 0;
     }

--- a/src/build.ts
+++ b/src/build.ts
@@ -243,7 +243,7 @@ export async function build(
             return chalk.gray(
               "  └─ " +
                 rPath(p) +
-                (chunk.bytes ? ` (${prettyBytes(chunk?.bytes)})` : "")
+                chalk.bold(chunk.bytes ? ` (${prettyBytes(chunk?.bytes)})` : "")
             );
           })
           .join("\n");
@@ -256,9 +256,9 @@ export async function build(
           .sort((a, b) => (b.bytes || 0) - (a.bytes || 0))
           .map((m) => {
             return chalk.gray(
-              "  └─ " +
+              "  📦 " +
                 rPath(m.id) +
-                (m.bytes ? ` (${prettyBytes(m.bytes)})` : "")
+                chalk.bold(m.bytes ? ` (${prettyBytes(m.bytes)})` : "")
             );
           })
           .join("\n");

--- a/src/build.ts
+++ b/src/build.ts
@@ -218,15 +218,15 @@ export async function build(
     relative(process.cwd(), resolve(options.outDir, p));
   for (const entry of ctx.buildEntries.filter((e) => !e.chunk)) {
     let totalBytes = entry.bytes || 0;
+    // consola.log(entry);
     for (const chunk of entry.chunks || []) {
       totalBytes += ctx.buildEntries.find((e) => e.path === chunk)?.bytes || 0;
     }
     let line =
       `  ${chalk.bold(rPath(entry.path))} (` +
       [
-        entry.bytes && `size: ${chalk.cyan(prettyBytes(entry.bytes))}`,
-        totalBytes !== entry.bytes &&
-          `total size: ${chalk.cyan(prettyBytes(totalBytes))}`,
+        totalBytes && `total size: ${chalk.cyan(prettyBytes(totalBytes))}`,
+        entry.bytes && `chunk size: ${chalk.cyan(prettyBytes(entry.bytes))}`,
         entry.exports?.length &&
           `exports: ${chalk.gray(entry.exports.join(", "))}`,
       ]
@@ -244,6 +244,21 @@ export async function build(
               "  └─ " +
                 rPath(p) +
                 (chunk.bytes ? ` (${prettyBytes(chunk?.bytes)})` : "")
+            );
+          })
+          .join("\n");
+    }
+    if (entry.modules?.length) {
+      line +=
+        "\n" +
+        entry.modules
+          .filter((m) => m.id.includes("node_modules"))
+          .sort((a, b) => (b.bytes || 0) - (a.bytes || 0))
+          .map((m) => {
+            return chalk.gray(
+              "  └─ " +
+                rPath(m.id) +
+                (m.bytes ? ` (${prettyBytes(m.bytes)})` : "")
             );
           })
           .join("\n");

--- a/src/builder/rollup.ts
+++ b/src/builder/rollup.ts
@@ -150,8 +150,7 @@ export async function rollupBuild(ctx: BuildContext) {
           chunks: entry.imports.filter((i) =>
             outputChunks.find((c) => c.fileName === i)
           ),
-          modules: entry.moduleIds.map((id) => {
-            const mod = entry.modules[id];
+          modules: Object.entries(entry.modules).map(([id, mod]) => {
             return {
               id,
               bytes: mod.renderedLength,

--- a/src/builder/rollup.ts
+++ b/src/builder/rollup.ts
@@ -150,6 +150,13 @@ export async function rollupBuild(ctx: BuildContext) {
           chunks: entry.imports.filter((i) =>
             outputChunks.find((c) => c.fileName === i)
           ),
+          modules: entry.moduleIds.map((id) => {
+            const mod = entry.modules[id];
+            return {
+              id,
+              bytes: mod.renderedLength,
+            };
+          }),
           path: entry.fileName,
           bytes: Buffer.byteLength(entry.code, "utf8"),
           exports: entry.exports,

--- a/src/builder/rollup.ts
+++ b/src/builder/rollup.ts
@@ -150,12 +150,10 @@ export async function rollupBuild(ctx: BuildContext) {
           chunks: entry.imports.filter((i) =>
             outputChunks.find((c) => c.fileName === i)
           ),
-          modules: Object.entries(entry.modules).map(([id, mod]) => {
-            return {
-              id,
-              bytes: mod.renderedLength,
-            };
-          }),
+          modules: Object.entries(entry.modules).map(([id, mod]) => ({
+            id,
+            bytes: mod.renderedLength,
+          })),
           path: entry.fileName,
           bytes: Buffer.byteLength(entry.code, "utf8"),
           exports: entry.exports,

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,6 +86,7 @@ export interface BuildContext {
     exports?: string[];
     chunks?: string[];
     chunk?: boolean;
+    modules?: { id: string; bytes: number }[];
   }[];
   usedImports: Set<string>;
   warnings: Set<string>;


### PR DESCRIPTION
When inlining node module dependencies, this can be helpful to analyze bundle impact for all modules.

<img width="1082" alt="image" src="https://user-images.githubusercontent.com/5158436/229120565-1ee4a211-c786-450e-a9fc-a9dd03d88235.png">
