### PR TITLE
fix(esbuild): only pass valid esbuild transform options

### DIFF
--- a/src/builder/plugins/esbuild.ts
+++ b/src/builder/plugins/esbuild.ts
@@ -13,7 +13,7 @@ const defaultLoaders: { [ext: string]: Loader } = {
   ".jsx": "jsx",
 };
 
-export interface Options extends Omit<CommonOptions, "sourcemap" | "loader"> {
+export interface Options extends Omit<CommonOptions, "loader"> {
   /** alias to `sourcemap` */
   sourceMap?: boolean;
 
@@ -88,7 +88,7 @@ export function esbuild({
         ...esbuildOptions,
         loader,
         sourcefile: id,
-        sourcemap: sourceMap,
+        sourcemap: sourceMap ?? esbuildOptions.sourcemap,
       });
 
       printWarnings(id, result, this);

--- a/src/builder/plugins/esbuild.ts
+++ b/src/builder/plugins/esbuild.ts
@@ -13,7 +13,7 @@ const defaultLoaders: { [ext: string]: Loader } = {
   ".jsx": "jsx",
 };
 
-export interface Options extends Omit<CommonOptions,'sourcemap' | 'loader'> {
+export interface Options extends Omit<CommonOptions, "sourcemap" | "loader"> {
   /** alias to `sourcemap` */
   sourceMap?: boolean;
 
@@ -35,14 +35,21 @@ export interface Options extends Omit<CommonOptions,'sourcemap' | 'loader'> {
   };
 }
 
-export function esbuild({ sourceMap, include, exclude, loaders: _loaders, tsconfig,  ...esbuildOptions }: Options): Plugin {
+export function esbuild({
+  sourceMap,
+  include,
+  exclude,
+  loaders: _loaders,
+  tsconfig,
+  ...esbuildOptions
+}: Options): Plugin {
   const loaders = {
     ...defaultLoaders,
   };
 
   if (_loaders) {
     for (const key of Object.keys(_loaders)) {
-      const value =_loaders[key];
+      const value = _loaders[key];
       if (typeof value === "string") {
         loaders[key] = value;
       } else if (value === false) {

--- a/test/fixture/build.config.ts
+++ b/test/fixture/build.config.ts
@@ -4,6 +4,10 @@ export default defineBuildConfig({
   preset: "./build.preset",
   rollup: {
     emitCJS: true,
+    esbuild: {
+      // This option does not have any effect for now， but the build process should pass
+      tsconfig: false,
+    }
   },
   entries: [
     "src/index",

--- a/test/fixture/build.config.ts
+++ b/test/fixture/build.config.ts
@@ -7,7 +7,7 @@ export default defineBuildConfig({
     esbuild: {
       // This option does not have any effect for now， but the build process should pass
       tsconfig: false,
-    }
+    },
   },
   entries: [
     "src/index",

--- a/test/fixture/src/index.ts
+++ b/test/fixture/src/index.ts
@@ -9,6 +9,8 @@ console.log(arch());
 console.log(require("node:os").arch());
 console.log(require.resolve("rollup"));
 console.log(testJSON);
+
+
 import("node:os").then((os) => console.log(os.arch()));
 
 // @ts-ignore

--- a/test/fixture/src/index.ts
+++ b/test/fixture/src/index.ts
@@ -10,7 +10,6 @@ console.log(require("node:os").arch());
 console.log(require.resolve("rollup"));
 console.log(testJSON);
 
-
 import("node:os").then((os) => console.log(os.arch()));
 
 // @ts-ignore


### PR DESCRIPTION
For now,  invalid `rollup.esbuild` options that aren't supported by `esbuild transform option` may breaks build, as #256 has shown.
This **PR** would fix:
- any esbuild option passed to unbuild should not break esbuild transform process
- since `loader` passed to `rollup.esbuild` have been overrided by inline handle logic, so inlined **esbuild option declaration** is also updated to reduce confusion. 

There is still one point as mentioned by #256, `tsconfig` has no effects in inline esbuild transform. I don't know would unbuild like to use it to resolve tsconfig file like `rollup-plugin-esbuild`, so I remained it unhandled.