### PR TITLE
fix(rollup): check module id against externals as well

### DIFF
--- a/src/builder/rollup.ts
+++ b/src/builder/rollup.ts
@@ -232,7 +232,7 @@ export function getRollupOptions(ctx: BuildContext): RollupOptions {
 
     external(id) {
       const pkg = getpkg(id);
-      const isExplicitExternal = arrayIncludes(ctx.options.externals, pkg);
+      const isExplicitExternal = arrayIncludes(ctx.options.externals, pkg) || arrayIncludes(ctx.options.externals, id);
       if (isExplicitExternal) {
         return true;
       }


### PR DESCRIPTION
With this change, it allows to externalize a specific module path like internal modules.

Fixes #269.