### PR TITLE
refactor(rollup)!: improve esbuild options handling

### DIFF
--- a/src/builder/plugins/esbuild.ts
+++ b/src/builder/plugins/esbuild.ts
@@ -13,7 +13,7 @@ const DefaultLoaders: { [ext: string]: Loader } = {
   ".jsx": "jsx",
 };
 
-export interface Options extends CommonOptions {
+export type ESBuildOptions = CommonOptions & {
   include?: FilterPattern;
   exclude?: FilterPattern;
 
@@ -24,9 +24,9 @@ export interface Options extends CommonOptions {
   loaders?: {
     [ext: string]: Loader | false;
   };
-}
+};
 
-export function esbuild(options: Options): Plugin {
+export function esbuild(options: ESBuildOptions): Plugin {
   // Extract esBuild options from additional options and apply defaults
   const {
     include = /\.(ts|js|tsx|jsx)$/,

--- a/src/builder/plugins/esbuild.ts
+++ b/src/builder/plugins/esbuild.ts
@@ -6,7 +6,7 @@ import { Loader, TransformResult, CommonOptions, transform } from "esbuild";
 import { createFilter } from "@rollup/pluginutils";
 import type { FilterPattern } from "@rollup/pluginutils";
 
-const defaultLoaders: { [ext: string]: Loader } = {
+const DefaultLoaders: { [ext: string]: Loader } = {
   ".ts": "ts",
   ".js": "js",
   ".tsx": "tsx",
@@ -14,17 +14,11 @@ const defaultLoaders: { [ext: string]: Loader } = {
 };
 
 export interface Options extends CommonOptions {
-  /** alias to `sourcemap` */
+  /** @deprecated Use `sourcemap` */
   sourceMap?: boolean;
 
   include?: FilterPattern;
   exclude?: FilterPattern;
-
-  /**
-   * Use this tsconfig file instead
-   * Disable it by setting to `false`
-   */
-  tsconfig?: string | false;
 
   /**
    * Map extension to esbuild loader
@@ -36,13 +30,19 @@ export interface Options extends CommonOptions {
 }
 
 export function esbuild(options: Options): Plugin {
-  const loaders = {
-    ...defaultLoaders,
-  };
+  // Extract esBuild options from additional options and apply defaults
+  const {
+    sourceMap,
+    include = /\.(ts|js|tsx|jsx)$/,
+    exclude = /node_modules/,
+    loaders: loaderOptions,
+    ...esbuildOptions
+  } = options;
 
-  if (options.loaders) {
-    for (const key of Object.keys(options.loaders)) {
-      const value = options.loaders[key];
+  // Rsolve loaders
+  const loaders = { ...DefaultLoaders };
+  if (loaderOptions) {
+    for (const [key, value] of Object.entries(loaderOptions)) {
       if (typeof value === "string") {
         loaders[key] = value;
       } else if (value === false) {
@@ -51,16 +51,7 @@ export function esbuild(options: Options): Plugin {
     }
   }
 
-  const extensions: string[] = Object.keys(loaders);
-  const INCLUDE_REGEXP = new RegExp(
-    `\\.(${extensions.map((ext) => ext.slice(1)).join("|")})$`
-  );
-  const EXCLUDE_REGEXP = /node_modules/;
-
-  const filter = createFilter(
-    options.include || INCLUDE_REGEXP,
-    options.exclude || EXCLUDE_REGEXP
-  );
+  const filter = createFilter(include, exclude);
 
   return {
     name: "esbuild",
@@ -78,10 +69,10 @@ export function esbuild(options: Options): Plugin {
       }
 
       const result = await transform(code, {
-        ...(options as any),
+        ...esbuildOptions,
         loader,
         sourcefile: id,
-        sourcemap: options.sourcemap ?? options.sourceMap,
+        sourcemap: options.sourcemap ?? sourceMap,
       });
 
       printWarnings(id, result, this);

--- a/src/builder/plugins/esbuild.ts
+++ b/src/builder/plugins/esbuild.ts
@@ -13,7 +13,7 @@ const DefaultLoaders: { [ext: string]: Loader } = {
   ".jsx": "jsx",
 };
 
-export type ESBuildOptions = CommonOptions & {
+export type EsbuildOptions = CommonOptions & {
   include?: FilterPattern;
   exclude?: FilterPattern;
 
@@ -26,7 +26,7 @@ export type ESBuildOptions = CommonOptions & {
   };
 };
 
-export function esbuild(options: ESBuildOptions): Plugin {
+export function esbuild(options: EsbuildOptions): Plugin {
   // Extract esBuild options from additional options and apply defaults
   const {
     include = /\.(ts|js|tsx|jsx)$/,

--- a/src/builder/plugins/esbuild.ts
+++ b/src/builder/plugins/esbuild.ts
@@ -14,9 +14,6 @@ const DefaultLoaders: { [ext: string]: Loader } = {
 };
 
 export interface Options extends CommonOptions {
-  /** @deprecated Use `sourcemap` */
-  sourceMap?: boolean;
-
   include?: FilterPattern;
   exclude?: FilterPattern;
 
@@ -32,7 +29,6 @@ export interface Options extends CommonOptions {
 export function esbuild(options: Options): Plugin {
   // Extract esBuild options from additional options and apply defaults
   const {
-    sourceMap,
     include = /\.(ts|js|tsx|jsx)$/,
     exclude = /node_modules/,
     loaders: loaderOptions,
@@ -72,7 +68,7 @@ export function esbuild(options: Options): Plugin {
         ...esbuildOptions,
         loader,
         sourcefile: id,
-        sourcemap: options.sourcemap ?? sourceMap,
+        sourcemap: options.sourcemap,
       });
 
       printWarnings(id, result, this);

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,7 +10,7 @@ import type { RollupNodeResolveOptions } from "@rollup/plugin-node-resolve";
 import type { RollupJsonOptions } from "@rollup/plugin-json";
 import type { Options as RollupDtsOptions } from "rollup-plugin-dts";
 import type commonjs from "@rollup/plugin-commonjs";
-import type { Options as EsbuildOptions } from "./builder/plugins/esbuild";
+import type { ESBuildOptions } from "./builder/plugins/esbuild";
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 export type RollupCommonJSOptions = Parameters<typeof commonjs>[0] & {};
@@ -54,7 +54,7 @@ export interface RollupBuildOptions {
   alias: RollupAliasOptions | false;
   resolve: RollupNodeResolveOptions | false;
   json: RollupJsonOptions | false;
-  esbuild: EsbuildOptions | false;
+  esbuild: ESBuildOptions | false;
   commonjs: RollupCommonJSOptions | false;
   dts: RollupDtsOptions;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,7 +10,7 @@ import type { RollupNodeResolveOptions } from "@rollup/plugin-node-resolve";
 import type { RollupJsonOptions } from "@rollup/plugin-json";
 import type { Options as RollupDtsOptions } from "rollup-plugin-dts";
 import type commonjs from "@rollup/plugin-commonjs";
-import type { ESBuildOptions } from "./builder/plugins/esbuild";
+import type { EsbuildOptions } from "./builder/plugins/esbuild";
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 export type RollupCommonJSOptions = Parameters<typeof commonjs>[0] & {};
@@ -54,7 +54,7 @@ export interface RollupBuildOptions {
   alias: RollupAliasOptions | false;
   resolve: RollupNodeResolveOptions | false;
   json: RollupJsonOptions | false;
-  esbuild: ESBuildOptions | false;
+  esbuild: EsbuildOptions | false;
   commonjs: RollupCommonJSOptions | false;
   dts: RollupDtsOptions;
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR improves esbuild option handling, separating custom options and removing unused `typescript` key and also remove deprecated `sourceMap` alias

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
