### PR TITLE
feat: support nested subpaths

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -1,7 +1,6 @@
 import Module from "node:module";
 import { promises as fsp } from "node:fs";
-import { isAbsolute, normalize } from "node:path";
-import { resolve, relative, basename } from "pathe";
+import { resolve, relative, isAbsolute, normalize } from "pathe";
 import type { PackageJson } from "pkg-types";
 import chalk from "chalk";
 import { consola } from "consola";

--- a/src/build.ts
+++ b/src/build.ts
@@ -1,5 +1,6 @@
 import Module from "node:module";
 import { promises as fsp } from "node:fs";
+import { isAbsolute, normalize } from "node:path";
 import { resolve, relative, basename } from "pathe";
 import type { PackageJson } from "pkg-types";
 import chalk from "chalk";
@@ -147,7 +148,13 @@ async function _build(
 
   for (const entry of options.entries) {
     if (typeof entry.name !== "string") {
-      entry.name = removeExtension(basename(entry.input));
+      let relativeInput = isAbsolute(entry.input)
+        ? relative(rootDir, entry.input)
+        : normalize(entry.input);
+      if (relativeInput.startsWith("./")) {
+        relativeInput = relativeInput.slice(2);
+      }
+      entry.name = removeExtension(relativeInput.replace(/^src\//, ""));
     }
 
     if (!entry.input) {

--- a/test/fixture/build.config.ts
+++ b/test/fixture/build.config.ts
@@ -1,6 +1,9 @@
 import { defineBuildConfig } from "../../src";
 
 export default defineBuildConfig([
+  // Auto preset
+  {},
+  // Custom preset
   {
     preset: "./build.preset",
     rollup: {
@@ -8,13 +11,12 @@ export default defineBuildConfig([
     },
     entries: [
       "./src/index.ts",
+      "./src/nested/subpath.ts",
       { input: "src/runtime/", outDir: "dist/runtime" },
       { input: "src/schema", builder: "untyped" },
     ],
   },
-  /**
-   * On top of that we run another build with a different config.
-   */
+  // Minified
   {
     name: "minified",
     entries: ["src/index"],

--- a/test/fixture/package.json
+++ b/test/fixture/package.json
@@ -2,6 +2,7 @@
   "name": "fixture",
   "private": "true",
   "exports": {
-    ".": "./dist/index.mjs"
+    ".": "./dist/index.mjs",
+    "./nested/subpath": "./dist/nested/subpath.mjs"
   }
 }

--- a/test/fixture/src/nested/subpath.ts
+++ b/test/fixture/src/nested/subpath.ts
@@ -1,0 +1,1 @@
+export default "nested/subpath";


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

Context: #251

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds support for nested subpaths (in a directory) for rollup builds (both automated and custom supported)

See implementation notes in https://github.com/unjs/unbuild/pull/251#issuecomment-1640113666

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
