### PR TITLE
feat: sourcemap support

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -95,6 +95,7 @@ async function _build(
       alias: {},
       replace: {},
       failOnWarn: true,
+      sourcemap: false,
       rollup: {
         emitCJS: false,
         cjsBridge: false,

--- a/src/builder/rollup.ts
+++ b/src/builder/rollup.ts
@@ -247,19 +247,22 @@ export function getRollupOptions(ctx: BuildContext): RollupOptions {
     ),
 
     output: [
-      ctx.options.rollup.emitCJS && {
-        dir: resolve(ctx.options.rootDir, ctx.options.outDir),
-        entryFileNames: "[name].cjs",
-        chunkFileNames: (chunk: PreRenderedChunk) =>
-          getChunkFilename(ctx, chunk, "cjs"),
-        format: "cjs",
-        exports: "auto",
-        interop: "compat",
-        generatedCode: { constBindings: true },
-        externalLiveBindings: false,
-        freeze: false,
-      },
-      {
+      ctx.options.rollup.emitCJS &&
+        <OutputOptions>{
+          dir: resolve(ctx.options.rootDir, ctx.options.outDir),
+          entryFileNames: "[name].cjs",
+          chunkFileNames: (chunk: PreRenderedChunk) =>
+            getChunkFilename(ctx, chunk, "cjs"),
+          format: "cjs",
+          exports: "auto",
+          interop: "compat",
+          generatedCode: { constBindings: true },
+          externalLiveBindings: false,
+          freeze: false,
+          sourcemap: ctx.options.sourcemap,
+          ...ctx.options.rollup.output,
+        },
+      <OutputOptions>{
         dir: resolve(ctx.options.rootDir, ctx.options.outDir),
         entryFileNames: "[name].mjs",
         chunkFileNames: (chunk: PreRenderedChunk) =>
@@ -269,6 +272,8 @@ export function getRollupOptions(ctx: BuildContext): RollupOptions {
         generatedCode: { constBindings: true },
         externalLiveBindings: false,
         freeze: false,
+        sourcemap: ctx.options.sourcemap,
+        ...ctx.options.rollup.output,
       },
     ].filter(Boolean),
 
@@ -332,6 +337,7 @@ export function getRollupOptions(ctx: BuildContext): RollupOptions {
 
       ctx.options.rollup.esbuild &&
         esbuild({
+          sourcemap: ctx.options.sourcemap,
           ...ctx.options.rollup.esbuild,
         }),
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,10 +25,15 @@ const main = defineCommand({
       type: "boolean",
       description: "Minify build",
     },
+    sourcemap: {
+      type: "boolean",
+      description: "Generate sourcemaps (experimental)",
+    },
   },
   async run({ args }) {
     const rootDir = resolve(process.cwd(), args.dir || ".");
     await build(rootDir, args.stub, {
+      sourcemap: args.sourcemap,
       rollup: {
         esbuild: {
           minify: args.minify,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-use-before-define */
 import type { PackageJson } from "pkg-types";
 import type { Hookable } from "hookable";
-import type { RollupOptions, RollupBuild } from "rollup";
+import type { RollupOptions, RollupBuild, OutputOptions } from "rollup";
 import type { MkdistOptions } from "mkdist";
 import type { Schema } from "untyped";
 import type { RollupReplaceOptions } from "@rollup/plugin-replace";
@@ -50,6 +50,7 @@ export interface RollupBuildOptions {
   emitCJS?: boolean;
   cjsBridge?: boolean;
   inlineDependencies?: boolean;
+  output?: OutputOptions;
   // Plugins
   replace: RollupReplaceOptions | false;
   alias: RollupAliasOptions | false;
@@ -65,6 +66,8 @@ export interface BuildOptions {
   rootDir: string;
   entries: BuildEntry[];
   clean: boolean;
+  /** @experimental */
+  sourcemap: boolean;
   /**
    * * `compatible` means "src/index.ts" will generate "dist/index.d.mts", "dist/index.d.cts" and "dist/index.d.ts".
    * * `node16` means "src/index.ts" will generate "dist/index.d.mts" and "dist/index.d.cts".


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

Resolves #236 also #47, #234

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This feature adds (more experimental) sourcemap support via top level `sourcemap: true` option and CLI `--sourcemap` (disabled by default).

Behavior can be fine-tuned for rollup using `rollup.output.sourcemap` and for esbuild using `rollup.esbuild.sourcemap`.

Unbuild support requires https://github.com/unjs/mkdist/issues/164


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
