### PR TITLE
fix(auto): avoid warning for existing files

### DIFF
--- a/src/auto.ts
+++ b/src/auto.ts
@@ -1,4 +1,5 @@
-import { normalize, join } from "pathe";
+import { existsSync } from "node:fs";
+import { normalize, join, resolve } from "pathe";
 import { consola } from "consola";
 import chalk from "chalk";
 import type { PackageJson } from "pkg-types";
@@ -21,7 +22,7 @@ export const autoPreset = definePreset(() => {
           return;
         }
         const sourceFiles = listRecursively(join(ctx.options.rootDir, "src"));
-        const res = inferEntries(ctx.pkg, sourceFiles);
+        const res = inferEntries(ctx.pkg, sourceFiles, ctx.options.rootDir);
         for (const message of res.warnings) {
           warn(ctx, message);
         }
@@ -66,6 +67,7 @@ export const autoPreset = definePreset(() => {
 export function inferEntries(
   pkg: PackageJson,
   sourceFiles: string[],
+  rootDir?: string,
 ): InferEntriesResult {
   const warnings = [];
 
@@ -135,7 +137,14 @@ export function inferEntries(
     }, undefined as any);
 
     if (!input) {
-      warnings.push(`Could not find entrypoint for ${output.file}`);
+      if (!existsSync(resolve(rootDir || ".", output.file))) {
+        warnings.push(
+          `Could not find entrypoint for ${output.file} ${resolve(
+            rootDir || ".",
+            output.file,
+          )}`,
+        );
+      }
       continue;
     }
 

--- a/src/auto.ts
+++ b/src/auto.ts
@@ -138,12 +138,7 @@ export function inferEntries(
 
     if (!input) {
       if (!existsSync(resolve(rootDir || ".", output.file))) {
-        warnings.push(
-          `Could not find entrypoint for ${output.file} ${resolve(
-            rootDir || ".",
-            output.file,
-          )}`,
-        );
+        warnings.push(`Could not find entrypoint for ${output.file}`);
       }
       continue;
     }

--- a/src/auto.ts
+++ b/src/auto.ts
@@ -138,7 +138,7 @@ export function inferEntries(
 
     if (!input) {
       if (!existsSync(resolve(rootDir || ".", output.file))) {
-        warnings.push(`Could not find entrypoint for ${output.file}`);
+        warnings.push(`Could not find entrypoint for \`${output.file}\``);
       }
       continue;
     }

--- a/test/auto.test.ts
+++ b/test/auto.test.ts
@@ -95,7 +95,7 @@ describe("inferEntries", () => {
       cjs: true,
       dts: false,
       entries: [{ input: "src/test" }],
-      warnings: ["Could not find entrypoint for custom/handwritten.d.ts"],
+      warnings: ["Could not find entrypoint for `custom/handwritten.d.ts`"],
     });
     expect(
       inferEntries(
@@ -160,7 +160,7 @@ describe("inferEntries", () => {
       cjs: false,
       entries: [],
       dts: false,
-      warnings: ["Could not find entrypoint for dist/test.js"],
+      warnings: ["Could not find entrypoint for `dist/test.js`"],
     });
   });
 

--- a/test/fixture/bin/cli.mjs
+++ b/test/fixture/bin/cli.mjs
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+console.log("hello");

--- a/test/fixture/package.json
+++ b/test/fixture/package.json
@@ -1,6 +1,9 @@
 {
   "name": "fixture",
   "private": "true",
+  "bin": {
+    "fixture": "./bin/cli.mjs"
+  },
   "exports": {
     ".": "./dist/index.mjs",
     "./nested/subpath": "./dist/nested/subpath.mjs"


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When a build entry exists outside of build tool, we should avoid making warnings.

Fun: I just spent today maintaining unbuild issues to only fix this one finally for listhen bin issue :D

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
