### PR TITLE
feat(rollup)!: default to `esnext` build target

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -117,7 +117,7 @@ async function _build(
         commonjs: {
           ignoreTryCatch: true,
         },
-        esbuild: { target: "es2020" },
+        esbuild: { target: "esnext" },
         dts: {
           // https://github.com/Swatinem/rollup-plugin-dts/issues/143
           compilerOptions: { preserveSymlinks: false },


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

https://github.com/nuxt/module-builder/pull/181#issuecomment-1794566118

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Not quite sure how to categorise, but this bumps esbuild target from `es2020` to `esnext`. However, we might consider using a year-bound target (https://esbuild.github.io/content-types/#javascript) to fix the feature-set.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
