### PR TITLE
fix: don't clean root directory if set as `outDir`

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "rollup": "^4.6.1",
     "rollup-plugin-dts": "^6.1.0",
     "scule": "^1.1.1",
+    "ufo": "^1.3.2",
     "untyped": "^1.4.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ dependencies:
   scule:
     specifier: ^1.1.1
     version: 1.1.1
+  ufo:
+    specifier: ^1.3.2
+    version: 1.3.2
   untyped:
     specifier: ^1.4.0
     version: 1.4.0
@@ -3433,7 +3436,7 @@ packages:
       acorn: 8.11.2
       pathe: 1.1.1
       pkg-types: 1.0.3
-      ufo: 1.3.1
+      ufo: 1.3.2
 
   /mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -3557,7 +3560,7 @@ packages:
     dependencies:
       destr: 2.0.2
       node-fetch-native: 1.4.1
-      ufo: 1.3.1
+      ufo: 1.3.2
     dev: true
 
   /ohash@1.1.3:
@@ -4626,8 +4629,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  /ufo@1.3.1:
-    resolution: {integrity: sha512-uY/99gMLIOlJPwATcMVYfqDSxUR9//AUcgZMzwfSTJPDKzA1S8mX4VLqa+fiAtveraQUBCz4FFcwVZBGbwBXIw==}
+  /ufo@1.3.2:
+    resolution: {integrity: sha512-o+ORpgGwaYQXgqGDwd+hkS4PuZ3QnmqMMxRuajK/a38L6fTpcE5GPIfrf+L/KemFzfUpeUQc1rRS1iDBozvnFA==}
 
   /unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}

--- a/src/build.ts
+++ b/src/build.ts
@@ -216,7 +216,7 @@ async function _build(
         .filter(Boolean)
         .sort() as unknown as Set<string>,
     )) {
-      if (cleanedDirs.some((c) => dir.startsWith(c))) {
+      if (dir === options.rootDir || cleanedDirs.some((c) => dir.startsWith(c))) {
         continue;
       }
       cleanedDirs.push(dir);

--- a/src/build.ts
+++ b/src/build.ts
@@ -1,6 +1,7 @@
 import Module from "node:module";
 import { promises as fsp } from "node:fs";
 import { resolve, relative, isAbsolute, normalize } from "pathe";
+import { withTrailingSlash } from "ufo";
 import type { PackageJson } from "pkg-types";
 import chalk from "chalk";
 import { consola } from "consola";
@@ -218,6 +219,7 @@ async function _build(
     )) {
       if (
         dir === options.rootDir ||
+        options.rootDir.startsWith(withTrailingSlash(dir)) ||
         cleanedDirs.some((c) => dir.startsWith(c))
       ) {
         continue;

--- a/src/build.ts
+++ b/src/build.ts
@@ -216,7 +216,10 @@ async function _build(
         .filter(Boolean)
         .sort() as unknown as Set<string>,
     )) {
-      if (dir === options.rootDir || cleanedDirs.some((c) => dir.startsWith(c))) {
+      if (
+        dir === options.rootDir ||
+        cleanedDirs.some((c) => dir.startsWith(c))
+      ) {
         continue;
       }
       cleanedDirs.push(dir);


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Let us draw a curtain of charity over how I discovered this issue.

I also considered warning + continue in this case but thought there would be valid use cases, such as wanting `./src/my-file.ts` to output to `./some-file.js`. However, if this is too edge-casey, I think we could add a warning as well.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
