### PR TITLE
refactor: replace `globby` w/ `fast-glob`

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "consola": "^3.2.3",
     "defu": "^6.1.4",
     "esbuild": "^0.23.0",
-    "globby": "^14.0.2",
+    "fast-glob": "^3.3.2",
     "hookable": "^5.5.3",
     "jiti": "^2.0.0-beta.3",
     "magic-string": "^0.30.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,9 +38,9 @@ importers:
       esbuild:
         specifier: ^0.23.0
         version: 0.23.0
-      globby:
-        specifier: ^14.0.2
-        version: 14.0.2
+      fast-glob:
+        specifier: ^3.3.2
+        version: 3.3.2
       hookable:
         specifier: ^5.5.3
         version: 5.5.3

--- a/src/build.ts
+++ b/src/build.ts
@@ -8,7 +8,7 @@ import { consola } from "consola";
 import { defu } from "defu";
 import { createHooks } from "hookable";
 import prettyBytes from "pretty-bytes";
-import { globby } from "globby";
+import fg from "fast-glob";
 import type { RollupOptions } from "rollup";
 import { dumpObject, rmdir, resolvePreset, removeExtension } from "./utils";
 import type { BuildContext, BuildConfig, BuildOptions } from "./types";
@@ -289,7 +289,7 @@ async function _build(
   consola.success(colors.green("Build succeeded for " + options.name));
 
   // Find all dist files and add missing entries as chunks
-  const outFiles = await globby("**", { cwd: options.outDir });
+  const outFiles = await fg("**", { cwd: options.outDir });
   for (const file of outFiles) {
     let entry = ctx.buildEntries.find((e) => e.path === file);
     if (!entry) {

--- a/src/builders/copy/index.ts
+++ b/src/builders/copy/index.ts
@@ -1,6 +1,6 @@
 import { promises as fsp } from "node:fs";
 import { relative, resolve } from "pathe";
-import { globby } from "globby";
+import fg from "fast-glob";
 import { symlink, rmdir, warn } from "../../utils";
 import type { CopyBuildEntry, BuildContext } from "../../types";
 import consola from "consola";
@@ -18,7 +18,7 @@ export async function copyBuild(ctx: BuildContext): Promise<void> {
       await rmdir(distDir);
       await symlink(entry.input, distDir);
     } else {
-      const paths = await globby(entry.pattern || ["**"], {
+      const paths = await fg(entry.pattern || ["**"], {
         cwd: resolve(ctx.options.rootDir, entry.input),
         absolute: false,
       });


### PR DESCRIPTION
Under the hood, `globby` is powered by `fast-glob` with extra features, but none of them are utilized by the `unbuild`.

Since the `unbuild` doesn't utilize those extra features, I propose replacing `globby` with `fast-glob` to reduce the installation size.

Here is globby's feature description:

- Promise API
  - `fast-glob` also has promise-based API
- Multiple patterns
  - `globby`'s multiple patterns support is powered by `fast-glob` directly
- Negated patterns: `['foo*', '!foobar']`
  - `globby`'s negated patterns support is also powered by `fast-glob` directly
- Expands directories: `foo → foo/**/*`
  - `unbuild` doesn't rely on this feature
- Supports `.gitignore` and similar ignore config files
  - `unbuild` doesn't rely on this feature since `globby` disabled this feature by default and `unbuild` doesn't enable it.
- Supports URL as `cwd`
  - Currently `unbuild` passed the string path to `cwd`, and we can use Node.js built-in  `url.fileURLToPath` in case we encounter URLs in the future.

See also https://github.com/typescript-eslint/typescript-eslint/issues/9453

