### PR TITLE
refactor: replace fast-glob with tinyglobby

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "consola": "^3.2.3",
     "defu": "^6.1.4",
     "esbuild": "^0.23.0",
-    "fast-glob": "^3.3.2",
     "hookable": "^5.5.3",
     "jiti": "2.0.0-beta.3",
     "magic-string": "^0.30.11",
@@ -52,6 +51,7 @@
     "rollup": "^4.20.0",
     "rollup-plugin-dts": "^6.1.1",
     "scule": "^1.3.0",
+    "tinyglobby": "^0.2.2",
     "ufo": "^1.5.4",
     "untyped": "^1.4.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,9 +38,6 @@ importers:
       esbuild:
         specifier: ^0.23.0
         version: 0.23.0
-      fast-glob:
-        specifier: ^3.3.2
-        version: 3.3.2
       hookable:
         specifier: ^5.5.3
         version: 5.5.3
@@ -74,6 +71,9 @@ importers:
       scule:
         specifier: ^1.3.0
         version: 1.3.0
+      tinyglobby:
+        specifier: ^0.2.2
+        version: 0.2.2
       ufo:
         specifier: ^1.5.4
         version: 1.5.4
@@ -448,7 +448,6 @@ packages:
   '@esbuild/linux-x64@0.23.0':
     resolution: {integrity: sha512-a3pMQhUEJkITgAw6e0bWA+F+vFtCciMjW/LPtoj99MhVt+Mfb6bbL9hu2wmTZgNd994qTAEw+U/r6k3qHWWaOQ==}
     engines: {node: '>=18'}
-    cpu: [x64]
     os: [linux]
 
   '@esbuild/netbsd-x64@0.21.5':
@@ -1303,6 +1302,14 @@ packages:
   fastq@1.17.1:
     resolution: {integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==}
 
+  fdir@6.2.0:
+    resolution: {integrity: sha512-9XaWcDl0riOX5j2kYfy0kKdg7skw3IY6kA4LFT8Tk2yF9UdrADUy8D6AJuBLtf7ISm/MksumwAHE3WVbMRyCLw==}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
@@ -1870,6 +1877,10 @@ packages:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
 
+  picomatch@4.0.2:
+    resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
+    engines: {node: '>=12'}
+
   pkg-types@1.1.3:
     resolution: {integrity: sha512-+JrgthZG6m3ckicaOB74TwQ+tBWsFl3qVQg7mN8ulwSOElJ7gBhKzj2VkCPnZ4NlF6kEquYU+RIYNVAvzd54UA==}
 
@@ -2262,6 +2273,10 @@ packages:
 
   tinybench@2.8.0:
     resolution: {integrity: sha512-1/eK7zUnIklz4JUUlL+658n58XO2hHLQfSk1Zf2LKieUjxidN16eKFEoDEfjHc3ohofSSqK3X5yO6VGb6iW8Lw==}
+
+  tinyglobby@0.2.2:
+    resolution: {integrity: sha512-mZ2sDMaySvi1PkTp4lTo1In2zjU+cY8OvZsfwrDrx3YGRbXPX1/cbPwCR9zkm3O/Fz9Jo0F1HNgIQ1b8BepqyQ==}
+    engines: {node: '>=12.0.0'}
 
   tinypool@1.0.0:
     resolution: {integrity: sha512-KIKExllK7jp3uvrNtvRBYBWBOAXSX8ZvoaD8T+7KB/QHIuoJW3Pmr60zucywjAlMb5TeXUkcs/MWeWLu0qvuAQ==}
@@ -3712,6 +3727,10 @@ snapshots:
     dependencies:
       reusify: 1.0.4
 
+  fdir@6.2.0(picomatch@4.0.2):
+    optionalDependencies:
+      picomatch: 4.0.2
+
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
@@ -4229,6 +4248,8 @@ snapshots:
 
   picomatch@2.3.1: {}
 
+  picomatch@4.0.2: {}
+
   pkg-types@1.1.3:
     dependencies:
       confbox: 0.1.7
@@ -4608,6 +4629,11 @@ snapshots:
   text-table@0.2.0: {}
 
   tinybench@2.8.0: {}
+
+  tinyglobby@0.2.2:
+    dependencies:
+      fdir: 6.2.0(picomatch@4.0.2)
+      picomatch: 4.0.2
 
   tinypool@1.0.0: {}
 

--- a/src/build.ts
+++ b/src/build.ts
@@ -8,7 +8,7 @@ import { consola } from "consola";
 import { defu } from "defu";
 import { createHooks } from "hookable";
 import prettyBytes from "pretty-bytes";
-import fg from "fast-glob";
+import { glob } from "tinyglobby";
 import type { RollupOptions } from "rollup";
 import { dumpObject, rmdir, resolvePreset, removeExtension } from "./utils";
 import type { BuildContext, BuildConfig, BuildOptions } from "./types";
@@ -289,7 +289,7 @@ async function _build(
   consola.success(colors.green("Build succeeded for " + options.name));
 
   // Find all dist files and add missing entries as chunks
-  const outFiles = await fg("**", { cwd: options.outDir });
+  const outFiles = await glob(["**"], { cwd: options.outDir });
   for (const file of outFiles) {
     let entry = ctx.buildEntries.find((e) => e.path === file);
     if (!entry) {

--- a/src/builders/copy/index.ts
+++ b/src/builders/copy/index.ts
@@ -1,6 +1,6 @@
 import { promises as fsp } from "node:fs";
 import { relative, resolve } from "pathe";
-import fg from "fast-glob";
+import { glob } from "tinyglobby";
 import { symlink, rmdir, warn } from "../../utils";
 import type { CopyBuildEntry, BuildContext } from "../../types";
 import consola from "consola";
@@ -18,7 +18,10 @@ export async function copyBuild(ctx: BuildContext): Promise<void> {
       await rmdir(distDir);
       await symlink(entry.input, distDir);
     } else {
-      const paths = await fg(entry.pattern || ["**"], {
+      const patterns = Array.isArray(entry.pattern)
+        ? entry.pattern
+        : [entry.pattern || "**"];
+      const paths = await glob(patterns, {
         cwd: resolve(ctx.options.rootDir, entry.input),
         absolute: false,
       });


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

[`fast-glob`](https://npmgraph.js.org/?q=fast-glob) - 17 subdependencies
[`tinyglobby`](https://npmgraph.js.org/?q=tinyglobby) - 2 subdependencies

https://github.com/es-tooling/module-replacements/blob/main/docs/modules/glob.md#tinyglobby

See unjs/mkdist#237

Like #418 but switches to an even smaller library