### PR TITLE
Revert "refactor: replace `globby` w/ `fast-glob` (#418)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "consola": "^3.2.3",
     "defu": "^6.1.4",
     "esbuild": "^0.23.0",
-    "fast-glob": "^3.3.2",
+    "globby": "^14.0.2",
     "hookable": "^5.5.3",
     "jiti": "2.0.0-beta.3",
     "magic-string": "^0.30.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,9 +38,9 @@ importers:
       esbuild:
         specifier: ^0.23.0
         version: 0.23.0
-      fast-glob:
-        specifier: ^3.3.2
-        version: 3.3.2
+      globby:
+        specifier: ^14.0.2
+        version: 14.0.2
       hookable:
         specifier: ^5.5.3
         version: 5.5.3

--- a/src/build.ts
+++ b/src/build.ts
@@ -8,7 +8,7 @@ import { consola } from "consola";
 import { defu } from "defu";
 import { createHooks } from "hookable";
 import prettyBytes from "pretty-bytes";
-import fg from "fast-glob";
+import { globby } from "globby";
 import type { RollupOptions } from "rollup";
 import { dumpObject, rmdir, resolvePreset, removeExtension } from "./utils";
 import type { BuildContext, BuildConfig, BuildOptions } from "./types";
@@ -289,7 +289,7 @@ async function _build(
   consola.success(colors.green("Build succeeded for " + options.name));
 
   // Find all dist files and add missing entries as chunks
-  const outFiles = await fg("**", { cwd: options.outDir });
+  const outFiles = await globby("**", { cwd: options.outDir });
   for (const file of outFiles) {
     let entry = ctx.buildEntries.find((e) => e.path === file);
     if (!entry) {

--- a/src/builders/copy/index.ts
+++ b/src/builders/copy/index.ts
@@ -1,6 +1,6 @@
 import { promises as fsp } from "node:fs";
 import { relative, resolve } from "pathe";
-import fg from "fast-glob";
+import { globby } from "globby";
 import { symlink, rmdir, warn } from "../../utils";
 import type { CopyBuildEntry, BuildContext } from "../../types";
 import consola from "consola";
@@ -18,7 +18,7 @@ export async function copyBuild(ctx: BuildContext): Promise<void> {
       await rmdir(distDir);
       await symlink(entry.input, distDir);
     } else {
-      const paths = await fg(entry.pattern || ["**"], {
+      const paths = await globby(entry.pattern || ["**"], {
         cwd: resolve(ctx.options.rootDir, entry.input),
         absolute: false,
       });


### PR DESCRIPTION
This reverts commit dd4b1a7171c661b973ad754855de9fe45c054848.

commit [dd4b1a7171c661b973ad754855de9fe45c054848 ](https://github.com/unjs/unbuild/commit/dd4b1a7171c661b973ad754855de9fe45c054848)  causes the following problem.

![image](https://github.com/user-attachments/assets/689bf8c7-c4de-4aa7-91af-a4bc35496657)

<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->
