### PR TITLE
(Draft) Rolldown support

### DIFF
--- a/examples/4.rolldown/build.config.ts
+++ b/examples/4.rolldown/build.config.ts
@@ -1,0 +1,14 @@
+import { defineBuildConfig } from "../../src";
+
+export default defineBuildConfig({
+  entries: [
+    "src/index.ts",
+  ],
+  declaration: true,
+  experimental: {
+    rolldown: true,
+  },
+  rollup: {
+    emitCJS: true,
+  },
+});

--- a/examples/4.rolldown/package.json
+++ b/examples/4.rolldown/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "unbuild-example-mkdist",
+  "version": "1.0.0",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "unbuild": "jiti ../../src/cli",
+    "build": "unbuild",
+    "build:stub": "unbuild --stub"
+  },
+  "devDependencies": {
+    "jiti": "^2.4.0",
+    "unbuild": "^2.0.0"
+  }
+}

--- a/examples/4.rolldown/pnpm-lock.yaml
+++ b/examples/4.rolldown/pnpm-lock.yaml
@@ -1,0 +1,26 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      jiti:
+        specifier: ^2.4.0
+        version: 2.4.0
+      unbuild:
+        specifier: ../../
+        version: link:../..
+
+packages:
+
+  jiti@2.4.0:
+    resolution: {integrity: sha512-H5UpaUI+aHOqZXlYOaFP/8AzKsg+guWu+Pr3Y8i7+Y3zr1aXAvCvTAQ1RxSc6oVD8R8c7brgNtTVP91E7upH/g==}
+    hasBin: true
+
+snapshots:
+
+  jiti@2.4.0: {}

--- a/examples/4.rolldown/src/index.ts
+++ b/examples/4.rolldown/src/index.ts
@@ -1,0 +1,3 @@
+export function main(data: string): string {
+  return `Hello ${data}!`;
+}

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "eslint": "^9.14.0",
     "eslint-config-unjs": "^0.4.1",
     "prettier": "^3.3.3",
+    "rolldown": "^0.15.0",
     "typescript": "^5.6.3",
     "vitest": "^2.1.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,9 @@ importers:
       prettier:
         specifier: ^3.3.3
         version: 3.3.3
+      rolldown:
+        specifier: ^0.14.0
+        version: 0.14.0
       typescript:
         specifier: ^5.6.3
         version: 5.6.3
@@ -270,6 +273,15 @@ packages:
 
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+
+  '@emnapi/core@1.3.1':
+    resolution: {integrity: sha512-pVGjBIt1Y6gg3EJN8jTcfpP/+uuRksIo055oE/OBkDNcjZqVbfkWCksG1Jp4yZnj3iKWyWX8fdG/j6UDYPbFog==}
+
+  '@emnapi/runtime@1.3.1':
+    resolution: {integrity: sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw==}
+
+  '@emnapi/wasi-threads@1.0.1':
+    resolution: {integrity: sha512-iIBu7mwkq4UQGeMEM8bLwNK962nXdhodeScX4slfQnRhEMMzvYivHhutCIk8uojvmASXXPC2WNEjwxFWk72Oqw==}
 
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
@@ -641,6 +653,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
+  '@napi-rs/wasm-runtime@0.2.5':
+    resolution: {integrity: sha512-kwUxR7J9WLutBbulqg1dfOrMTwhMdXLdcGUhcbCcGwnPLt3gz19uHVdwH1syKVDbE022ZS2vZxOWflFLS0YTjw==}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -732,6 +747,66 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@rolldown/binding-darwin-arm64@0.14.0':
+    resolution: {integrity: sha512-0GneNB1lW+k6VyBeKZAAyjoJ27r+gCDV+xI56aifQteaHAhFb0q8etJE5KpOOt65Hz0xXVjENilDKS+ibn1lcA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@0.14.0':
+    resolution: {integrity: sha512-MG+pbDhufD2Fkua7J32XAkK6OoHzS/P1KFwDv+J7YvD6KZ/vEz8GklXtM4Woby+rbvbNmgoT4MV1BtHENONr3A==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@0.14.0':
+    resolution: {integrity: sha512-ojbJdM8f6+099WfFL/ggQ0F5o2/lHypQBj7WgIPL2Iqr3KleRVN57YTZPu0SJ/bK0OWrx2ZaWBLb6WpDsIx2zg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@0.14.0':
+    resolution: {integrity: sha512-cI8UBQDS6xFWg6Pe5gPXZYXskt2BQ4nVEoGGaHZsav8PWC31cEZhSkUj814anbmGoi7wl23/T2gNuCNysdWHxg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@0.14.0':
+    resolution: {integrity: sha512-vA2ewz6nun7mkW4lMwO3TzCuUi3mpcAo3xXhAwmIPT6yz7+ofJGLkq3N7oYfJQhH9ktHSEPA8JzPHvZ1ozAfgA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@0.14.0':
+    resolution: {integrity: sha512-uEoG+tzi0JqCVhuWmaOLR7hjuyDQ+a9OudYDeArkeAD2tY8fNyd9gAOfjzyYhgBcYvOLCo+4w2C3GnoSKy88FA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@0.14.0':
+    resolution: {integrity: sha512-WSeo4JfiXCTRJDT5VG5Ohp3nhZittMrRA42wZjcHRajsuG7YsikmkSbTI88TXVjMSdXJBQK1zsBVOIpYfzKltQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@0.14.0':
+    resolution: {integrity: sha512-gR9Xz+k2E5Xjd/6d+109Jpdwtaepa4Y0UvAA1hwMBM7LsDR0tMpryRYJlrKqaFvhFyzMfd45HunrX4dttQV5hQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-wasm32-wasi@0.14.0':
+    resolution: {integrity: sha512-5tEWnRnWlxgn45Z/LGL0Ds/gZ/B8dY84PfKNq6S1elweLGgjlhDSRbNaZiX/umvELa9e1dbYNPCFZiEhHSUvkQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@0.14.0':
+    resolution: {integrity: sha512-VIdWQkE0vvaORRy0NXW+z+IuqTZ96/FbVKVFKlsOMcrhBOibzvy8LobKaxUIOPJ/WzPEyrmhnMRHJpWbtaPJmw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-ia32-msvc@0.14.0':
+    resolution: {integrity: sha512-0nOHZhjcX93FiY6SLk0iMTqFf3wzRXYsneGstfIlkob8tEncukMdS+iv9JfG9k15e5fRYcwfHu8wW55qmLYj/w==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@0.14.0':
+    resolution: {integrity: sha512-RKNpJKIG5J6dgR/0IpxHmZkYYnHJE8vDm3qL8Zq9EY7kxOsCNZbrj5leU7qbibqfHHR+9Ij4vhTL1YuLz/ch5Q==}
+    cpu: [x64]
+    os: [win32]
 
   '@rollup/plugin-alias@5.1.1':
     resolution: {integrity: sha512-PR9zDb+rOzkRb2VD+EuKB7UC41vU5DIwZ5qqCpk0KJudcWAyi8rvYOhS7+L5aZCspw1stTViLgN5v6FF1p5cgQ==}
@@ -884,6 +959,9 @@ packages:
   '@trysound/sax@0.2.0':
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
     engines: {node: '>=10.13.0'}
+
+  '@tybys/wasm-util@0.9.0':
+    resolution: {integrity: sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==}
 
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
@@ -2286,6 +2364,10 @@ packages:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  rolldown@0.14.0:
+    resolution: {integrity: sha512-9mb66Rwe3iGFBxFGQLahhoPzL2655VyObBParkFZ8EoH4rAYF67D4oKEqQKri5Fl8pAgtgLBt1wDCS54cBgmnw==}
+    hasBin: true
+
   rollup-plugin-dts@6.1.1:
     resolution: {integrity: sha512-aSHRcJ6KG2IHIioYlvAOcEq6U99sVtqDDKVhnwt70rW6tsz3tv5OSjEiWcgzfsHdLyGXZ/3b/7b/+Za3Y6r1XA==}
     engines: {node: '>=16'}
@@ -2460,6 +2542,9 @@ packages:
     peerDependencies:
       typescript: '>=4.2.0'
 
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -2615,6 +2700,9 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod@3.23.8:
+    resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
 
 snapshots:
 
@@ -2842,6 +2930,22 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
+  '@emnapi/core@1.3.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.0.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.3.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.0.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
 
@@ -3067,6 +3171,13 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
+  '@napi-rs/wasm-runtime@0.2.5':
+    dependencies:
+      '@emnapi/core': 1.3.1
+      '@emnapi/runtime': 1.3.1
+      '@tybys/wasm-util': 0.9.0
+    optional: true
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -3136,6 +3247,44 @@ snapshots:
       '@parcel/watcher-win32-x64': 2.4.1
 
   '@pkgjs/parseargs@0.11.0':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@0.14.0':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@0.14.0':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@0.14.0':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@0.14.0':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@0.14.0':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@0.14.0':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@0.14.0':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@0.14.0':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@0.14.0':
+    dependencies:
+      '@napi-rs/wasm-runtime': 0.2.5
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@0.14.0':
+    optional: true
+
+  '@rolldown/binding-win32-ia32-msvc@0.14.0':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@0.14.0':
     optional: true
 
   '@rollup/plugin-alias@5.1.1(rollup@4.25.0)':
@@ -3242,6 +3391,11 @@ snapshots:
   '@sindresorhus/merge-streams@2.3.0': {}
 
   '@trysound/sax@0.2.0': {}
+
+  '@tybys/wasm-util@0.9.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@types/estree@1.0.6': {}
 
@@ -4760,6 +4914,23 @@ snapshots:
 
   reusify@1.0.4: {}
 
+  rolldown@0.14.0:
+    dependencies:
+      zod: 3.23.8
+    optionalDependencies:
+      '@rolldown/binding-darwin-arm64': 0.14.0
+      '@rolldown/binding-darwin-x64': 0.14.0
+      '@rolldown/binding-freebsd-x64': 0.14.0
+      '@rolldown/binding-linux-arm-gnueabihf': 0.14.0
+      '@rolldown/binding-linux-arm64-gnu': 0.14.0
+      '@rolldown/binding-linux-arm64-musl': 0.14.0
+      '@rolldown/binding-linux-x64-gnu': 0.14.0
+      '@rolldown/binding-linux-x64-musl': 0.14.0
+      '@rolldown/binding-wasm32-wasi': 0.14.0
+      '@rolldown/binding-win32-arm64-msvc': 0.14.0
+      '@rolldown/binding-win32-ia32-msvc': 0.14.0
+      '@rolldown/binding-win32-x64-msvc': 0.14.0
+
   rollup-plugin-dts@6.1.1(rollup@4.25.0)(typescript@5.6.3):
     dependencies:
       magic-string: 0.30.12
@@ -4934,6 +5105,9 @@ snapshots:
     dependencies:
       typescript: 5.6.3
 
+  tslib@2.8.1:
+    optional: true
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -5085,3 +5259,5 @@ snapshots:
   yaml@2.5.1: {}
 
   yocto-queue@0.1.0: {}
+
+  zod@3.23.8: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,8 +106,8 @@ importers:
         specifier: ^3.3.3
         version: 3.3.3
       rolldown:
-        specifier: ^0.14.0
-        version: 0.14.0
+        specifier: ^0.15.0
+        version: 0.15.0(@babel/runtime@7.25.7)
       typescript:
         specifier: ^5.6.3
         version: 5.6.3
@@ -748,63 +748,63 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
-  '@rolldown/binding-darwin-arm64@0.14.0':
-    resolution: {integrity: sha512-0GneNB1lW+k6VyBeKZAAyjoJ27r+gCDV+xI56aifQteaHAhFb0q8etJE5KpOOt65Hz0xXVjENilDKS+ibn1lcA==}
+  '@rolldown/binding-darwin-arm64@0.15.0':
+    resolution: {integrity: sha512-3Z0aZbYGfXC2gqh7rjC+PXzwIVqUR1SZJ5VDc970q/jm6Pc+uKd52zZMe8DCEAw2JZeEP7LjDgK1nYbm1+LfnA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@0.14.0':
-    resolution: {integrity: sha512-MG+pbDhufD2Fkua7J32XAkK6OoHzS/P1KFwDv+J7YvD6KZ/vEz8GklXtM4Woby+rbvbNmgoT4MV1BtHENONr3A==}
+  '@rolldown/binding-darwin-x64@0.15.0':
+    resolution: {integrity: sha512-u5eFb9ELXxKz583pEopJYNQn4wfefBCSXrks0t3EwrEN3uGS96kTzdMLI/M2/FlODWh/KM3Ilu/o1m+CeFJbIw==}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@0.14.0':
-    resolution: {integrity: sha512-ojbJdM8f6+099WfFL/ggQ0F5o2/lHypQBj7WgIPL2Iqr3KleRVN57YTZPu0SJ/bK0OWrx2ZaWBLb6WpDsIx2zg==}
+  '@rolldown/binding-freebsd-x64@0.15.0':
+    resolution: {integrity: sha512-00aLb4gX9W4ILMOaEIfigjl+aZw7giwSwrdus/rqTuNf0JveDSeRSvxlvLmPzGf4q0ds8m6pvuzvrXor0bFIBA==}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@0.14.0':
-    resolution: {integrity: sha512-cI8UBQDS6xFWg6Pe5gPXZYXskt2BQ4nVEoGGaHZsav8PWC31cEZhSkUj814anbmGoi7wl23/T2gNuCNysdWHxg==}
+  '@rolldown/binding-linux-arm-gnueabihf@0.15.0':
+    resolution: {integrity: sha512-9cLQ4lhfC+SaqAI6tffc6fySFPu0z4TAddI+nFVqTGHj5k0FlA2XjAIQc75gJzWQLKXY0ABMAK5clR4BNutyOQ==}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@0.14.0':
-    resolution: {integrity: sha512-vA2ewz6nun7mkW4lMwO3TzCuUi3mpcAo3xXhAwmIPT6yz7+ofJGLkq3N7oYfJQhH9ktHSEPA8JzPHvZ1ozAfgA==}
+  '@rolldown/binding-linux-arm64-gnu@0.15.0':
+    resolution: {integrity: sha512-iNKwZCCgWXJoclvOMWzZFO1OChcShWc/8NFM8X4vDH8OvSs+iFhXD0a1dkh0p6PuAv9Ik4wQ8kw04dJGX4GKEQ==}
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-musl@0.14.0':
-    resolution: {integrity: sha512-uEoG+tzi0JqCVhuWmaOLR7hjuyDQ+a9OudYDeArkeAD2tY8fNyd9gAOfjzyYhgBcYvOLCo+4w2C3GnoSKy88FA==}
+  '@rolldown/binding-linux-arm64-musl@0.15.0':
+    resolution: {integrity: sha512-DJYSyPq6Uqtwp2vmTPWjUm9CpJflPMGxYWcp6uIlFWpOo3xuNQcYBTHBz1edpAi1A7Y/mQLMNrvpMUSe9Wabmw==}
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-gnu@0.14.0':
-    resolution: {integrity: sha512-WSeo4JfiXCTRJDT5VG5Ohp3nhZittMrRA42wZjcHRajsuG7YsikmkSbTI88TXVjMSdXJBQK1zsBVOIpYfzKltQ==}
+  '@rolldown/binding-linux-x64-gnu@0.15.0':
+    resolution: {integrity: sha512-JXwfBwxOy+6GgGLPMWzRrJgbB6c4vjwIDLSuzK0r1JymoFIWGCMVTywOtFIUxJkyKfujbUj1chjB/h0mFnci5w==}
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-musl@0.14.0':
-    resolution: {integrity: sha512-gR9Xz+k2E5Xjd/6d+109Jpdwtaepa4Y0UvAA1hwMBM7LsDR0tMpryRYJlrKqaFvhFyzMfd45HunrX4dttQV5hQ==}
+  '@rolldown/binding-linux-x64-musl@0.15.0':
+    resolution: {integrity: sha512-7XknATUDYY1/X3vI6+0fZNCCj6Qkqco7mjtp+gIlG75eWJD6gxaMksm5nCpFbnR9RWtt04dfy2c/SXUzNiZ/SA==}
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-wasm32-wasi@0.14.0':
-    resolution: {integrity: sha512-5tEWnRnWlxgn45Z/LGL0Ds/gZ/B8dY84PfKNq6S1elweLGgjlhDSRbNaZiX/umvELa9e1dbYNPCFZiEhHSUvkQ==}
+  '@rolldown/binding-wasm32-wasi@0.15.0':
+    resolution: {integrity: sha512-3D5d2XC3xrMjD/1J/3Ye4O+QjOgaZ31Ovg2Q/fE4VipmIyqt0V1M7pbqwZWB9Cgb7b2WlmY5cYkvmsmOWZbEpQ==}
     engines: {node: '>=14.21.3'}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@0.14.0':
-    resolution: {integrity: sha512-VIdWQkE0vvaORRy0NXW+z+IuqTZ96/FbVKVFKlsOMcrhBOibzvy8LobKaxUIOPJ/WzPEyrmhnMRHJpWbtaPJmw==}
+  '@rolldown/binding-win32-arm64-msvc@0.15.0':
+    resolution: {integrity: sha512-52p+iB4nCaK8eDGb4TRF6GKSfzb4GG5fg864C0Pdq+ncdUAIN/lrTyIAkFQlTLiuGZbLhlZ+vDYcmZjs5nifbQ==}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-ia32-msvc@0.14.0':
-    resolution: {integrity: sha512-0nOHZhjcX93FiY6SLk0iMTqFf3wzRXYsneGstfIlkob8tEncukMdS+iv9JfG9k15e5fRYcwfHu8wW55qmLYj/w==}
+  '@rolldown/binding-win32-ia32-msvc@0.15.0':
+    resolution: {integrity: sha512-KJMBZVQu8uRpfJp/vBg6+7ipI9LoE2HWhhaKju8XcujcMJV/PmJWHD6I0M+l1WTYcvQLIRS7d83dsOhv56s3tg==}
     cpu: [ia32]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@0.14.0':
-    resolution: {integrity: sha512-RKNpJKIG5J6dgR/0IpxHmZkYYnHJE8vDm3qL8Zq9EY7kxOsCNZbrj5leU7qbibqfHHR+9Ij4vhTL1YuLz/ch5Q==}
+  '@rolldown/binding-win32-x64-msvc@0.15.0':
+    resolution: {integrity: sha512-HlakXIO1Hi/eqqfYors4JxKsa8bH5upnWwbYO8IAduaqT7XLoMshagvA3+8Kf4mVWdKFIaqhJaO0E0vstEeM+g==}
     cpu: [x64]
     os: [win32]
 
@@ -2364,9 +2364,14 @@ packages:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
-  rolldown@0.14.0:
-    resolution: {integrity: sha512-9mb66Rwe3iGFBxFGQLahhoPzL2655VyObBParkFZ8EoH4rAYF67D4oKEqQKri5Fl8pAgtgLBt1wDCS54cBgmnw==}
+  rolldown@0.15.0:
+    resolution: {integrity: sha512-R+OnyuN+t91ZszrNmBRG/1rIPFEH4RuBGYX9lDnCNXvz74w9bxZxzpyUK0bOhxXiNeWPVoylrH/itJJAUDSTEw==}
     hasBin: true
+    peerDependencies:
+      '@babel/runtime': '>=7'
+    peerDependenciesMeta:
+      '@babel/runtime':
+        optional: true
 
   rollup-plugin-dts@6.1.1:
     resolution: {integrity: sha512-aSHRcJ6KG2IHIioYlvAOcEq6U99sVtqDDKVhnwt70rW6tsz3tv5OSjEiWcgzfsHdLyGXZ/3b/7b/+Za3Y6r1XA==}
@@ -3249,42 +3254,42 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@0.14.0':
+  '@rolldown/binding-darwin-arm64@0.15.0':
     optional: true
 
-  '@rolldown/binding-darwin-x64@0.14.0':
+  '@rolldown/binding-darwin-x64@0.15.0':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@0.14.0':
+  '@rolldown/binding-freebsd-x64@0.15.0':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@0.14.0':
+  '@rolldown/binding-linux-arm-gnueabihf@0.15.0':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@0.14.0':
+  '@rolldown/binding-linux-arm64-gnu@0.15.0':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@0.14.0':
+  '@rolldown/binding-linux-arm64-musl@0.15.0':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@0.14.0':
+  '@rolldown/binding-linux-x64-gnu@0.15.0':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@0.14.0':
+  '@rolldown/binding-linux-x64-musl@0.15.0':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@0.14.0':
+  '@rolldown/binding-wasm32-wasi@0.15.0':
     dependencies:
       '@napi-rs/wasm-runtime': 0.2.5
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@0.14.0':
+  '@rolldown/binding-win32-arm64-msvc@0.15.0':
     optional: true
 
-  '@rolldown/binding-win32-ia32-msvc@0.14.0':
+  '@rolldown/binding-win32-ia32-msvc@0.15.0':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@0.14.0':
+  '@rolldown/binding-win32-x64-msvc@0.15.0':
     optional: true
 
   '@rollup/plugin-alias@5.1.1(rollup@4.25.0)':
@@ -4914,22 +4919,23 @@ snapshots:
 
   reusify@1.0.4: {}
 
-  rolldown@0.14.0:
+  rolldown@0.15.0(@babel/runtime@7.25.7):
     dependencies:
       zod: 3.23.8
     optionalDependencies:
-      '@rolldown/binding-darwin-arm64': 0.14.0
-      '@rolldown/binding-darwin-x64': 0.14.0
-      '@rolldown/binding-freebsd-x64': 0.14.0
-      '@rolldown/binding-linux-arm-gnueabihf': 0.14.0
-      '@rolldown/binding-linux-arm64-gnu': 0.14.0
-      '@rolldown/binding-linux-arm64-musl': 0.14.0
-      '@rolldown/binding-linux-x64-gnu': 0.14.0
-      '@rolldown/binding-linux-x64-musl': 0.14.0
-      '@rolldown/binding-wasm32-wasi': 0.14.0
-      '@rolldown/binding-win32-arm64-msvc': 0.14.0
-      '@rolldown/binding-win32-ia32-msvc': 0.14.0
-      '@rolldown/binding-win32-x64-msvc': 0.14.0
+      '@babel/runtime': 7.25.7
+      '@rolldown/binding-darwin-arm64': 0.15.0
+      '@rolldown/binding-darwin-x64': 0.15.0
+      '@rolldown/binding-freebsd-x64': 0.15.0
+      '@rolldown/binding-linux-arm-gnueabihf': 0.15.0
+      '@rolldown/binding-linux-arm64-gnu': 0.15.0
+      '@rolldown/binding-linux-arm64-musl': 0.15.0
+      '@rolldown/binding-linux-x64-gnu': 0.15.0
+      '@rolldown/binding-linux-x64-musl': 0.15.0
+      '@rolldown/binding-wasm32-wasi': 0.15.0
+      '@rolldown/binding-win32-arm64-msvc': 0.15.0
+      '@rolldown/binding-win32-ia32-msvc': 0.15.0
+      '@rolldown/binding-win32-x64-msvc': 0.15.0
 
   rollup-plugin-dts@6.1.1(rollup@4.25.0)(typescript@5.6.3):
     dependencies:

--- a/src/builders/rolldown/build.ts
+++ b/src/builders/rolldown/build.ts
@@ -1,0 +1,37 @@
+import { rolldown } from 'rolldown';
+import type { BuildContext } from "../../types";
+import { getRolldownOptions } from "./config";
+import { warn } from '../../utils';
+
+/**
+ * TODO: add description
+ * @param ctx 
+ */
+export async function rolldownBuild(ctx: BuildContext): Promise<void> {
+  /** Print warning that rolldown is still a experimental feature */
+  warn(
+    ctx,
+    "You are using an experimental feature [rolldown], please report any issues you encounter.",
+  );
+
+  /** Define entries */
+  const entries = ctx.options.entries.filter(
+    (e) => e.builder === "rolldown",
+  );
+
+  if (entries.length === 0) {
+    return;
+  }
+
+  /** Define build options */
+  const rolldownConfig = getRolldownOptions(ctx);
+
+  /**
+   * Make rolldown build - we need to do that in a loop because we cannot have multiple outputs
+   * @see https://github.com/rolldown/rolldown/blob/main/packages/rolldown/src/cli/commands/bundle.ts#L24
+   */
+  for (const entry of rolldownConfig) {
+    const bundler = await rolldown(entry);
+    await bundler.write(entry.output)
+  }
+}

--- a/src/builders/rolldown/config.ts
+++ b/src/builders/rolldown/config.ts
@@ -1,0 +1,87 @@
+import type { PreRenderedChunk, RolldownOptions } from "rolldown";
+import type { BuildContext, RolldownBuildEntry } from "../../types";
+import { isAbsolute, resolve } from "pathe";
+import { getChunkFilename, resolveAlias, resolveAliases } from "../rollup/utils";
+import { arrayIncludes, getpkg, warn } from "../../utils";
+
+export function getRolldownOptions(ctx: BuildContext): RolldownOptions[] {
+  /** Define rolldown confits */
+  const configs: RolldownOptions[] = [
+    // add base config for ESM
+    getConfig(ctx, false),
+  ];
+
+  /** Add CJS config if needed */
+  if (ctx.options.rollup.emitCJS) {
+    configs.push(getConfig(ctx, true));
+  }
+
+  return configs;
+
+}
+
+function getConfig(ctx: BuildContext, emitCJS = false): RolldownOptions {
+  /** Define helpers */
+  const isCJS = emitCJS ?? false;
+  const moduleType = (isCJS) ? "cjs" : "mjs";
+  const format = (isCJS) ? "cjs" : "esm";
+
+  /** Define aliases */
+  const _aliases = resolveAliases(ctx);
+
+  /** Define inputs */
+  const _input = Object.fromEntries(
+    ctx.options.entries
+      .filter((entry) => entry.builder === "rolldown")
+      .map((entry) => [
+        entry.name,
+        resolve(ctx.options.rootDir, entry.input),
+      ]),
+  );
+  
+  /** Define output */
+  const _output: RolldownOptions["output"] = {
+    dir: resolve(ctx.options.rootDir, ctx.options.outDir),
+    entryFileNames: `[name].${moduleType}`,
+    chunkFileNames: (chunk: PreRenderedChunk) => {
+      return getChunkFilename(ctx, chunk, moduleType);
+    },
+    format,
+    exports: "auto",
+    externalLiveBindings: true,
+    sourcemap: ctx.options.sourcemap,
+  }
+
+  return {
+    input: _input,
+    output: _output,
+    external(id): boolean {
+      id = resolveAlias(id, _aliases);
+      const pkg = getpkg(id);
+      const isExplicitExternal =
+        arrayIncludes(ctx.options.externals, pkg) ||
+        arrayIncludes(ctx.options.externals, id);
+      if (isExplicitExternal) {
+        return true;
+      }
+      if (
+        ctx.options.rollup.inlineDependencies ||
+        id[0] === "." ||
+        isAbsolute(id) ||
+        /src[/\\]/.test(id) ||
+        id.startsWith(ctx.pkg.name!)
+      ) {
+        return false;
+      }
+      if (!isExplicitExternal) {
+        warn(ctx, `Inlined implicit external ${id}`);
+      }
+      return isExplicitExternal;
+    },
+    onwarn(warning, rolldownWarn): void {
+      if (!warning.code || !["CIRCULAR_DEPENDENCY"].includes(warning.code)) {
+        rolldownWarn(warning);
+      }
+    },
+  }
+}

--- a/src/builders/rolldown/index.ts
+++ b/src/builders/rolldown/index.ts
@@ -1,0 +1,1 @@
+export { rolldownBuild } from "./build";

--- a/src/builders/rollup/utils.ts
+++ b/src/builders/rollup/utils.ts
@@ -1,4 +1,5 @@
-import type { PreRenderedChunk } from "rollup";
+import type { PreRenderedChunk as _RollupPreRenderedChunk } from "rollup";
+import type { PreRenderedChunk as _RolldownPreRenderedChunk } from "rolldown";
 import type { BuildContext } from "../../types";
 
 export const DEFAULT_EXTENSIONS: string[] = [
@@ -55,7 +56,7 @@ export function resolveAlias(
 
 export function getChunkFilename(
   ctx: BuildContext,
-  chunk: PreRenderedChunk,
+  chunk: _RollupPreRenderedChunk | _RolldownPreRenderedChunk,
   ext: string,
 ): string {
   if (chunk.isDynamicEntry) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,7 +21,7 @@ import type { EsbuildOptions } from "./builders/rollup/plugins/esbuild";
 export type RollupCommonJSOptions = Parameters<typeof commonjs>[0] & {};
 
 export interface BaseBuildEntry {
-  builder?: "untyped" | "rollup" | "mkdist" | "copy";
+  builder?: "untyped" | "rollup" | "mkdist" | "copy" | "rolldown";
   input: string;
   name?: string;
   outDir?: string;
@@ -42,6 +42,10 @@ export interface MkdistBuildEntry extends _BaseAndMkdist {
   builder: "mkdist";
 }
 
+export interface RolldownBuildEntry extends BaseBuildEntry {
+  bundler: "rolldown";
+}
+
 export interface CopyBuildEntry extends BaseBuildEntry {
   builder: "copy";
   pattern?: string | string[];
@@ -52,7 +56,8 @@ export type BuildEntry =
   | RollupBuildEntry
   | UntypedBuildEntry
   | MkdistBuildEntry
-  | CopyBuildEntry;
+  | CopyBuildEntry
+  | RolldownBuildEntry;
 
 export interface RollupBuildOptions {
   /**
@@ -259,6 +264,8 @@ export type BuildPreset = BuildConfig | (() => BuildConfig);
 
 type DeepPartial<T> = { [P in keyof T]?: DeepPartial<T[P]> };
 
+export type ExperimentalKeys = "rolldown";
+
 /**
  * In addition to basic `entries`, `presets`, and `hooks`,
  * there are also all the properties of `BuildOptions` except for BuildOptions's `entries`.
@@ -280,6 +287,13 @@ export interface BuildConfig
    * This configuration allows you to insert custom logic during the build process to meet specific requirements or perform additional operations.
    */
   hooks?: Partial<BuildHooks>;
+
+  /**
+   * Specify experimental features.
+   */
+  experimental?: {
+    [K in ExperimentalKeys]?: boolean;
+  }
 }
 
 export interface UntypedOutput {


### PR DESCRIPTION
This PR is WIP example of implementation [rolldown](https://rolldown.rs/) as next bundler for the project.

Resolves https://github.com/unjs/unbuild/issues/451

Todo:
- [ ]  Support for `d.ts` (see https://github.com/rolldown/rolldown/issues/819)
- [ ] Support for TS-Decorators (see https://github.com/rolldown/rolldown/issues/2296)
- [ ] Watch mode
- [ ] Support for rollup plugins