### PR TITLE
refactor: split types for bundlers

### DIFF
--- a/src/builders/copy/types.ts
+++ b/src/builders/copy/types.ts
@@ -1,0 +1,14 @@
+import type { BaseBuildEntry, BuildContext } from "../../types";
+
+export interface CopyBuildEntry extends BaseBuildEntry {
+  builder: "copy";
+  pattern?: string | string[];
+}
+
+export interface CopyHooks {
+  "copy:entries": (
+    ctx: BuildContext,
+    entries: CopyBuildEntry[],
+  ) => void | Promise<void>;
+  "copy:done": (ctx: BuildContext) => void | Promise<void>;
+}

--- a/src/builders/mkdist/types.ts
+++ b/src/builders/mkdist/types.ts
@@ -1,0 +1,25 @@
+import type { MkdistOptions } from "mkdist";
+import type { BuildContext, BaseBuildEntry } from "../../types";
+
+type _BaseAndMkdist = BaseBuildEntry & MkdistOptions;
+export interface MkdistBuildEntry extends _BaseAndMkdist {
+  builder: "mkdist";
+}
+
+export interface MkdistHooks {
+  "mkdist:entries": (
+    ctx: BuildContext,
+    entries: MkdistBuildEntry[],
+  ) => void | Promise<void>;
+  "mkdist:entry:options": (
+    ctx: BuildContext,
+    entry: MkdistBuildEntry,
+    options: MkdistOptions,
+  ) => void | Promise<void>;
+  "mkdist:entry:build": (
+    ctx: BuildContext,
+    entry: MkdistBuildEntry,
+    output: { writtenFiles: string[] },
+  ) => void | Promise<void>;
+  "mkdist:done": (ctx: BuildContext) => void | Promise<void>;
+}

--- a/src/builders/rollup/types.ts
+++ b/src/builders/rollup/types.ts
@@ -1,0 +1,128 @@
+import type {
+  RollupOptions as _RollupOptions,
+  RollupBuild,
+  OutputOptions,
+  InputPluginOption,
+} from "rollup";
+import type { RollupReplaceOptions } from "@rollup/plugin-replace";
+import type { RollupAliasOptions } from "@rollup/plugin-alias";
+import type { RollupNodeResolveOptions } from "@rollup/plugin-node-resolve";
+import type { RollupJsonOptions } from "@rollup/plugin-json";
+import type { Options as RollupDtsOptions } from "rollup-plugin-dts";
+import type commonjs from "@rollup/plugin-commonjs";
+import type { BaseBuildEntry } from "../../types";
+import type { BuildContext } from "../../types";
+import type { EsbuildOptions } from "./plugins/esbuild";
+
+export type RollupCommonJSOptions = Parameters<typeof commonjs>[0] & {};
+
+export interface RollupBuildEntry extends BaseBuildEntry {
+  builder: "rollup";
+}
+
+export interface RollupBuildOptions {
+  /**
+   * If enabled, unbuild generates a CommonJS build in addition to the ESM build.
+   */
+  emitCJS?: boolean;
+
+  /**
+   * Enable experimental active watcher
+   *
+   * @experimental
+   */
+  watch?: boolean;
+
+  /**
+   * If enabled, unbuild generates CommonJS polyfills for ESM builds.
+   */
+  cjsBridge?: boolean;
+
+  /**
+   * Preserve dynamic imports as-is
+   */
+  preserveDynamicImports?: boolean;
+
+  /**
+   * Inline dependencies nor explicitly set in "dependencies" or "peerDependencies" or as marked externals to the bundle.
+   */
+  inlineDependencies?: boolean;
+
+  /**
+   * Rollup [Output Options](https://rollupjs.org/configuration-options)
+   */
+  output?: OutputOptions;
+
+  /**
+   * Replace plugin options
+   * Set to `false` to disable the plugin.
+   * Read more: [@rollup/plugin-replace](https://www.npmjs.com/package/@rollup/plugin-replace)
+   */
+  replace: RollupReplaceOptions | false;
+
+  /**
+   * Alias plugin options
+   * Set to `false` to disable the plugin.
+   * Read more: [@rollup/plugin-alias](https://www.npmjs.com/package/@rollup/plugin-alias)
+   */
+  alias: RollupAliasOptions | false;
+
+  /**
+   * Resolve plugin options
+   * Set to `false` to disable the plugin.
+   * Read more: [@rollup/plugin-node-resolve](https://www.npmjs.com/package/@rollup/plugin-node-resolve)
+   */
+  resolve: RollupNodeResolveOptions | false;
+
+  /**
+   * JSON plugin options
+   * Set to `false` to disable the plugin.
+   * Read more: [@rollup/plugin-json](https://www.npmjs.com/package/@rollup/plugin-json)
+   */
+  json: RollupJsonOptions | false;
+
+  /**
+   * ESBuild plugin options
+   * Set to `false` to disable the plugin.
+   * Read more: [esbuild](https://www.npmjs.com/package/esbuild)
+   */
+  esbuild: EsbuildOptions | false;
+
+  /**
+   * CommonJS plugin options
+   * Set to `false` to disable the plugin.
+   * Read more: [@rollup/plugin-commonjs](https://www.npmjs.com/package/@rollup/plugin-commonjs)
+   */
+  commonjs: RollupCommonJSOptions | false;
+
+  /**
+   * DTS plugin options
+   * Set to `false` to disable the plugin.
+   * Read more: [rollup-plugin-dts](https://www.npmjs.com/package/rollup-plugin-dts)
+   */
+  dts: RollupDtsOptions;
+}
+
+export interface RollupOptions extends _RollupOptions {
+  plugins: InputPluginOption[];
+}
+
+export interface RollupHooks {
+  "rollup:options": (
+    ctx: BuildContext,
+    options: RollupOptions,
+  ) => void | Promise<void>;
+  "rollup:build": (
+    ctx: BuildContext,
+    build: RollupBuild,
+  ) => void | Promise<void>;
+  "rollup:dts:options": (
+    ctx: BuildContext,
+    options: RollupOptions,
+  ) => void | Promise<void>;
+  "rollup:dts:build": (
+    ctx: BuildContext,
+    build: RollupBuild,
+  ) => void | Promise<void>;
+  "rollup:done": (ctx: BuildContext) => void | Promise<void>;
+}

--- a/src/builders/untyped/types.ts
+++ b/src/builders/untyped/types.ts
@@ -1,0 +1,42 @@
+import type { Schema } from "untyped";
+import type { BaseBuildEntry, BuildContext } from "../../types";
+
+export interface UntypedBuildEntry extends BaseBuildEntry {
+  builder: "untyped";
+  defaults?: Record<string, any>;
+}
+
+export interface UntypedOutput {
+  fileName: string;
+  contents: string;
+}
+
+export interface UntypedOutputs {
+  markdown: UntypedOutput;
+  schema: UntypedOutput;
+  defaults: UntypedOutput;
+  declaration?: UntypedOutput;
+}
+
+export interface UntypedHooks {
+  "untyped:entries": (
+    ctx: BuildContext,
+    entries: UntypedBuildEntry[],
+  ) => void | Promise<void>;
+  "untyped:entry:options": (
+    ctx: BuildContext,
+    entry: UntypedBuildEntry,
+    options: any,
+  ) => void | Promise<void>;
+  "untyped:entry:schema": (
+    ctx: BuildContext,
+    entry: UntypedBuildEntry,
+    schema: Schema,
+  ) => void | Promise<void>;
+  "untyped:entry:outputs": (
+    ctx: BuildContext,
+    entry: UntypedBuildEntry,
+    outputs: UntypedOutputs,
+  ) => void | Promise<void>;
+  "untyped:done": (ctx: BuildContext) => void | Promise<void>;
+}


### PR DESCRIPTION
This PR refactors the type definitions to improve clarity and maintainability. Previously, all types for different bundlers were grouped in a single file, which led to confusion and increased difficulty when making changes.

With this update:
* Each bundler now has its own dedicated file for type definitions.
* This structure makes it easier to locate and manage the types related to a specific bundler.

This change aims to simplify future modifications and enhance the overall developer experience.
Let me know if there are any additional improvements or concerns!