### PR TITLE
fix: de-default default export from stub

### DIFF
--- a/src/builders/rollup/stub.ts
+++ b/src/builders/rollup/stub.ts
@@ -144,7 +144,7 @@ export async function rollupStub(ctx: BuildContext): Promise<void> {
           `const _module = await jiti.import(${JSON.stringify(
             resolvedEntry,
           )});`,
-          hasDefaultExport ? "\nexport default _module;" : "",
+          hasDefaultExport ? "\nexport default _module.default || _module;" : "",
           ...namedExports
             .filter((name) => name !== "default")
             .map((name) => `export const ${name} = _module.${name};`),


### PR DESCRIPTION
Testing latest unbuild with module-builder:

```ts
const _module = await jiti.import("/Users/daniel/code/nuxt/fonts/src/module.ts");

export default _module;
```
... and then
```ts
nuxtModule = await jiti.import(src, { default: true });
```

nuxtModule is '[object AsyncFunction]' and you access the module from `nuxtModule.default`