### PR TITLE
feat(rollup): resolve with `production` condition

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@rollup/plugin-alias": "^5.1.1",
     "@rollup/plugin-commonjs": "^28.0.2",
     "@rollup/plugin-json": "^6.1.0",
-    "@rollup/plugin-node-resolve": "^15.3.1",
+    "@rollup/plugin-node-resolve": "^16.0.0",
     "@rollup/plugin-replace": "^6.0.2",
     "@rollup/pluginutils": "^5.1.4",
     "citty": "^0.1.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^6.1.0
         version: 6.1.0(rollup@4.29.1)
       '@rollup/plugin-node-resolve':
-        specifier: ^15.3.1
-        version: 15.3.1(rollup@4.29.1)
+        specifier: ^16.0.0
+        version: 16.0.0(rollup@4.29.1)
       '@rollup/plugin-replace':
         specifier: ^6.0.2
         version: 6.0.2(rollup@4.29.1)
@@ -727,8 +727,8 @@ packages:
       rollup:
         optional: true
 
-  '@rollup/plugin-node-resolve@15.3.1':
-    resolution: {integrity: sha512-tgg6b91pAybXHJQMAAwW9VuWBO6Thi+q7BCNARLwSqlmsHz0XYURtGvh/AuwSADXSI4h/2uHbs7s4FzlZDGSGA==}
+  '@rollup/plugin-node-resolve@16.0.0':
+    resolution: {integrity: sha512-0FPvAeVUT/zdWoO0jnb/V5BlBsUSNfkIOtFHzMO4H9MOklrmQFY6FduVHKucNb/aTFxvnGhj4MNj/T1oNdDfNg==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       rollup: ^2.78.0||^3.0.0||^4.0.0
@@ -3027,7 +3027,7 @@ snapshots:
     optionalDependencies:
       rollup: 4.29.1
 
-  '@rollup/plugin-node-resolve@15.3.1(rollup@4.29.1)':
+  '@rollup/plugin-node-resolve@16.0.0(rollup@4.29.1)':
     dependencies:
       '@rollup/pluginutils': 5.1.4(rollup@4.29.1)
       '@types/resolve': 1.20.2

--- a/src/builders/rollup/config.ts
+++ b/src/builders/rollup/config.ts
@@ -110,6 +110,7 @@ export function getRollupOptions(ctx: BuildContext): RollupOptions {
       ctx.options.rollup.resolve &&
         nodeResolve({
           extensions: DEFAULT_EXTENSIONS,
+          exportConditions: ["production"],
           ...ctx.options.rollup.resolve,
         }),
 


### PR DESCRIPTION
`@rollup/plugin-node-resolve` v16 enforces conditions to have at least `production` or `development`. Default is infered from `NODE_ENV` and if (is set and) it is not `=== "production"` (which in many scripts is not) will become `development`. (more info: https://github.com/rollup/plugins/pull/1823)

this PR updates plugin + uses `["production"]` as the condition by default to ensure prod optimized builds (overridable by users still)