### PR TITLE
fix: only externalize `@types/` from `devDependencies`

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -167,7 +167,9 @@ export function inferPkgExternals(pkg: PackageJson): (string | RegExp)[] {
   const externals: (string | RegExp)[] = [
     ...Object.keys(pkg.dependencies || {}),
     ...Object.keys(pkg.peerDependencies || {}),
-    ...Object.keys(pkg.devDependencies || {}),
+    ...Object.keys(pkg.devDependencies || {}).filter((dep) =>
+      dep.startsWith("@types/"),
+    ),
     ...Object.keys(pkg.optionalDependencies || {}),
   ];
 

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -61,7 +61,7 @@ describe("inferPkgExternals", () => {
         name: "test",
         dependencies: { react: "17.0.0" },
         peerDependencies: { "react-dom": "17.0.0" },
-        devDependencies: { "@types/react": "17.0.0" },
+        devDependencies: { "@types/react": "17.0.0", webpack: "*" },
         optionalDependencies: { test: "1.0.0", optional: "1.0.0" },
         exports: {
           ".": "index.js",


### PR DESCRIPTION
#469 wrongly added all `devDependencies` as externals which is wrong (they are not shipped). this PR adds only `@types/*` dev deps as implicit externals which is usually desired.