### PR TITLE
feat(mkdist): fail build if `mkdist` errors in creating declarations

### DIFF
--- a/src/builders/mkdist/index.ts
+++ b/src/builders/mkdist/index.ts
@@ -1,6 +1,6 @@
 import { relative } from "pathe";
 import { mkdist, type MkdistOptions } from "mkdist";
-import { symlink, rmdir } from "../../utils";
+import { symlink, rmdir, warn } from "../../utils";
 import type { MkdistBuildEntry, BuildContext } from "../../types";
 import consola from "consola";
 
@@ -34,6 +34,14 @@ export async function mkdistBuild(ctx: BuildContext): Promise<void> {
         chunks: output.writtenFiles.map((p) => relative(ctx.options.outDir, p)),
       });
       await ctx.hooks.callHook("mkdist:entry:build", ctx, entry, output);
+      if (output.errors) {
+        for (const error of output.errors) {
+          warn(
+            ctx,
+            `mkdist build failed for \`${relative(ctx.options.rootDir, error.filename)}\`:\n${error.errors.map((e) => `  - ${e}`).join("\n")}`,
+          );
+        }
+      }
     }
   }
   await ctx.hooks.callHook("mkdist:done", ctx);


### PR DESCRIPTION
This uses compiler error data from `mkdist` to respect `failOnWarn` from `unbuild`:

![CleanShot 2024-12-28 at 22 45 48@2x](https://github.com/user-attachments/assets/2c68b6a3-34ef-4184-8a4a-663420c67b93)

Note: TS is very forgiving and I had to set `noEmitOnError: true` to generate an error for testing. Normally TS errors like the one shown in the screenshot don't cause issues emitting declarations.