### PR TITLE
fix: filter commonjs plugin when generating declaration

### DIFF
--- a/src/builders/rollup/build.ts
+++ b/src/builders/rollup/build.ts
@@ -83,7 +83,14 @@ export async function rollupBuild(ctx: BuildContext): Promise<void> {
       dts(ctx.options.rollup.dts),
       removeShebangPlugin(),
       ctx.options.rollup.emitCJS && fixCJSExportTypePlugin(),
-    ].filter(Boolean);
+    ].filter((plugin) => 
+      /**
+       * Issue: #396
+       * rollup-plugin-dts conflicts with rollup-plugin-commonjs:
+       * https://github.com/Swatinem/rollup-plugin-dts?tab=readme-ov-file#what-to-expect
+       */
+      plugin && (!("name" in plugin) || plugin.name !== "commonjs")
+    );
 
     await ctx.hooks.callHook("rollup:dts:options", ctx, rollupOptions);
     const typesBuild = await rollup(rollupOptions);

--- a/src/builders/rollup/build.ts
+++ b/src/builders/rollup/build.ts
@@ -83,13 +83,14 @@ export async function rollupBuild(ctx: BuildContext): Promise<void> {
       dts(ctx.options.rollup.dts),
       removeShebangPlugin(),
       ctx.options.rollup.emitCJS && fixCJSExportTypePlugin(),
-    ].filter((plugin) => 
-      /**
-       * Issue: #396
-       * rollup-plugin-dts conflicts with rollup-plugin-commonjs:
-       * https://github.com/Swatinem/rollup-plugin-dts?tab=readme-ov-file#what-to-expect
-       */
-      plugin && (!("name" in plugin) || plugin.name !== "commonjs")
+    ].filter(
+      (plugin) =>
+        /**
+         * Issue: #396
+         * rollup-plugin-dts conflicts with rollup-plugin-commonjs:
+         * https://github.com/Swatinem/rollup-plugin-dts?tab=readme-ov-file#what-to-expect
+         */
+        plugin && (!("name" in plugin) || plugin.name !== "commonjs"),
     );
 
     await ctx.hooks.callHook("rollup:dts:options", ctx, rollupOptions);


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

resolves #396
resolves #135

The rollup-plugin-dts conflicts with @rollup/plugin-commonjs:

> The plugin does its own import resolution through the typescript compiler, and usage together with other resolution plugins, such as node-resolve can lead to errors and is not recommended.
> [rollup-plugin-dts - what-to-expect](https://github.com/Swatinem/rollup-plugin-dts?tab=readme-ov-file#what-to-expect)

I'm not sure if it's okay to simply remove @rollup/plugin-commonjs when generating declarations. 🤔 
I've tested some common cases, and it's working fine.
