### PR TITLE
feat(build): add ignoreConditions option to BuildOptions

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -126,6 +126,7 @@ async function _build(
       dependencies: [],
       devDependencies: [],
       peerDependencies: [],
+      ignoreConditions: [],
       alias: {},
       replace: {},
       failOnWarn: true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -143,6 +143,12 @@ export interface BuildOptions {
    * Run different types of builds (untyped, mkdist, Rollup, copy) simultaneously.
    */
   parallel: boolean;
+
+  /**
+   * Ignore conditions.
+   * If the condition is met, the build will be ignored.
+   */
+  ignoreConditions: string[];
 }
 
 export interface BuildContext {

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -55,6 +55,22 @@ export function validatePackage(
     return;
   }
 
+  for (const item of ctx.options.ignoreConditions || []) {
+    if (typeof pkg.exports === "object" && !Array.isArray(pkg.exports)) {
+      for (const key of Object.keys(pkg.exports)) {
+        const exportEntry = pkg.exports[key];
+        if (
+          exportEntry &&
+          typeof exportEntry === "object" &&
+          !Array.isArray(exportEntry) &&
+          exportEntry[item] !== undefined
+        ) {
+          delete exportEntry[item];
+        }
+      }
+    }
+  }
+
   const filenames = new Set(
     [
       ...(typeof pkg.bin === "string"


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

When we use custom Conditions, TypeScript throws errors when dealing with paths, etc. In reality, we only need this during development. That’s why we want to disable these Conditions during the build process. This is why I came up with this new structure.


```diff
diff --git a/dist/shared/unbuild.B2_7OVir.mjs b/dist/shared/unbuild.B2_7OVir.mjs
index 89838b3093726b0bdd864943be4eb480e74ecbea..48d45f6a36242042c1505b2400880c3a77c55912 100644
--- a/dist/shared/unbuild.B2_7OVir.mjs
+++ b/dist/shared/unbuild.B2_7OVir.mjs
@@ -329,6 +329,17 @@ function validatePackage(pkg, rootDir, ctx) {
   if (!pkg) {
     return;
   }
+  for (const item of ctx.options.ignoreConditions || []) {
+    if (typeof pkg.exports === 'object' && !Array.isArray(pkg.exports)) {
+      for (const key of Object.keys(pkg.exports)) {
+        const exportEntry = pkg.exports[key];
+        if (exportEntry && typeof exportEntry === 'object' 
+          && !Array.isArray(exportEntry) && exportEntry[item] !== undefined) {
+            delete exportEntry[item];
+          }
+      }
+    }
+  }
   const filenames = new Set(
     [
       ...typeof pkg.bin === "string" ? [pkg.bin] : Object.values(pkg.bin || {}),

```


