### PR TITLE
fix(cjs): include `d.ts` cjs transformation when cjs package

### DIFF
--- a/src/builders/rollup/plugins/cjs.ts
+++ b/src/builders/rollup/plugins/cjs.ts
@@ -18,7 +18,7 @@ export function cjsPlugin(_opts?: any): Plugin {
 
 export function fixCJSExportTypePlugin(ctx: BuildContext): Plugin {
   const regexp =
-    ctx.options.declaration === "node16"
+    ctx.pkg.type === "module"
       ? /\.d\.cts$/ // d.cts only
       : /\.d\.c?ts$/; // d.ts and d.cts
   return FixDtsDefaultCjsExportsPlugin({


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

Right now, we're generating wrong CJS `d.ts` files based on declaration option and we shoud check the package is **NOT ESM** ; we only need to transform `d.ts` files when type !== module.

/cc @pio

Check **unjs/destr** below and this gh repro: https://github.com/userquin/destr-consola-test

<details>
<summary><strong>unjs/destr</strong></summary>

![image](https://github.com/user-attachments/assets/583f8b83-60f5-4572-a50e-1242a830eae7)
_unjs/destr_

![image](https://github.com/user-attachments/assets/82784397-417f-434b-8766-364795b13545)
_unjs/destr at arethetypeswrong_

![image](https://github.com/user-attachments/assets/4692cdd5-3b49-4a19-9b1b-4f6d37e4fba3)
_unjs/destr/package.json_

```json
  "exports": {
    ".": {
      "import": "./dist/index.mjs",
      "require": "./dist/index.cjs"
    }
  },
  "main": "./dist/index.cjs",
  "module": "./dist/index.mjs",
  "types": "./dist/index.d.ts",
```
_unjs/destr exports_
</details>
