### PR TITLE
fix: omit `declaration` from builders that do not support it

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "prepack": "pnpm unbuild",
     "release": "pnpm test && changelogen --release --publish && git push --follow-tags",
     "stub": "pnpm unbuild --stub",
-    "test": "pnpm lint && pnpm test:types && vitest run --coverage",
+    "test": "pnpm lint && pnpm test:types && vitest run --coverage --typecheck",
     "test:types": "tsc --noEmit",
     "unbuild": "jiti ./src/cli"
   },

--- a/src/build.ts
+++ b/src/build.ts
@@ -229,8 +229,12 @@ async function _build(
       entry.builder = entry.input.endsWith("/") ? "mkdist" : "rollup";
     }
 
-    if (options.declaration !== undefined && entry.declaration === undefined) {
-      entry.declaration = options.declaration;
+    if (
+      (entry.builder === "mkdist" || entry.builder === "untyped") &&
+      options.declaration !== undefined &&
+      entry.declaration === undefined
+    ) {
+      entry.declaration = options.declaration ? true : false;
     }
 
     entry.input = resolve(options.rootDir, entry.input);

--- a/src/builders/copy/types.ts
+++ b/src/builders/copy/types.ts
@@ -1,6 +1,6 @@
 import type { BaseBuildEntry, BuildContext } from "../../types";
 
-export interface CopyBuildEntry extends BaseBuildEntry {
+export interface CopyBuildEntry extends Omit<BaseBuildEntry, "declaration"> {
   builder: "copy";
   pattern?: string | string[];
 }

--- a/src/builders/mkdist/types.ts
+++ b/src/builders/mkdist/types.ts
@@ -1,8 +1,9 @@
 import type { MkdistOptions } from "mkdist";
 import type { BuildContext, BaseBuildEntry } from "../../types";
 
-type _BaseAndMkdist = BaseBuildEntry & MkdistOptions;
-export interface MkdistBuildEntry extends _BaseAndMkdist {
+export interface MkdistBuildEntry
+  extends Omit<BaseBuildEntry, "declaration">,
+    MkdistOptions {
   builder: "mkdist";
 }
 

--- a/src/builders/rollup/types.ts
+++ b/src/builders/rollup/types.ts
@@ -2,7 +2,6 @@ import type {
   RollupOptions as _RollupOptions,
   RollupBuild,
   OutputOptions,
-  InputPluginOption,
   Plugin,
 } from "rollup";
 import type { RollupReplaceOptions } from "@rollup/plugin-replace";
@@ -17,7 +16,7 @@ import type { EsbuildOptions } from "./plugins/esbuild";
 
 export type RollupCommonJSOptions = Parameters<typeof commonjs>[0] & {};
 
-export interface RollupBuildEntry extends BaseBuildEntry {
+export interface RollupBuildEntry extends Omit<BaseBuildEntry, "declaration"> {
   builder: "rollup";
 }
 

--- a/src/builders/untyped/types.ts
+++ b/src/builders/untyped/types.ts
@@ -1,9 +1,10 @@
 import type { Schema } from "untyped";
 import type { BaseBuildEntry, BuildContext } from "../../types";
 
-export interface UntypedBuildEntry extends BaseBuildEntry {
+export interface UntypedBuildEntry extends Omit<BaseBuildEntry, "declaration"> {
   builder: "untyped";
   defaults?: Record<string, any>;
+  declaration?: boolean;
 }
 
 export interface UntypedOutput {

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,7 +16,7 @@ export interface BaseBuildEntry {
   input: string;
   name?: string;
   outDir?: string;
-  declaration?: "compatible" | "node16" | boolean;
+  declaration?: never;
 }
 
 /** Bundler types */

--- a/test/types.test-d.ts
+++ b/test/types.test-d.ts
@@ -1,0 +1,54 @@
+import { describe, it } from "vitest";
+import { defineBuildConfig } from "../src";
+
+describe("types", () => {
+  it("defineBuildConfig - parameters should be type-safe", () => {
+    defineBuildConfig({
+      entries: [
+        "src/index.ts",
+
+        { input: "src/index.ts" },
+        // @ts-expect-error "declaration" shouldn't be allowed when no builder is specified
+        { input: "src/index.ts", declaration: true },
+
+        { input: "src/index.ts", builder: "rollup" },
+        // @ts-expect-error "declaration" shouldn't be allowed with "rollup" builder
+        {
+          input: "src/index.ts",
+          builder: "rollup",
+          declaration: true,
+        },
+        {
+          input: "src/index.ts",
+          builder: "mkdist",
+        },
+        {
+          input: "src/index.ts",
+          builder: "mkdist",
+          declaration: true,
+        },
+
+        {
+          input: "src/index.ts",
+          builder: "untyped",
+        },
+        {
+          input: "src/index.ts",
+          builder: "untyped",
+          declaration: true,
+        },
+
+        {
+          input: "src/index.ts",
+          builder: "copy",
+        },
+        // @ts-expect-error "declaration" shouldn't be allowed with "copy" builder
+        {
+          input: "src/index.ts",
+          builder: "copy",
+          declaration: true,
+        },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
resolves #529
