### PR TITLE
docs: remove wrong jsdoc for `dts` type

### DIFF
--- a/src/builders/rollup/types.ts
+++ b/src/builders/rollup/types.ts
@@ -101,7 +101,6 @@ export interface RollupBuildOptions {
 
   /**
    * DTS plugin options
-   * Set to `false` to disable the plugin.
    * Read more: [rollup-plugin-dts](https://www.npmjs.com/package/rollup-plugin-dts)
    */
   dts: RollupDtsOptions;


### PR DESCRIPTION
resolves https://github.com/unjs/unbuild/issues/539