### PR TITLE
fix: use pathToFileURL for stubbed absolute path

### DIFF
--- a/src/builders/rollup/stub.ts
+++ b/src/builders/rollup/stub.ts
@@ -1,7 +1,12 @@
 import { writeFile, mkdir } from "node:fs/promises";
 import { promises as fsp } from "node:fs";
 import { resolve, dirname, extname, relative } from "pathe";
-import { resolvePath, resolveModuleExportNames, fileURLToPath, pathToFileURL } from "mlly";
+import {
+  resolvePath,
+  resolveModuleExportNames,
+  fileURLToPath,
+  pathToFileURL,
+} from "mlly";
 import { warn } from "../../utils";
 import type { BuildContext } from "../../types";
 import { makeExecutable, getShebang } from "./plugins/shebang";
@@ -13,7 +18,7 @@ export async function rollupStub(ctx: BuildContext): Promise<void> {
   const importedBabelPlugins: Array<string> = [];
   // #542
   const jitiImportResolve = ctx.options.stubOptions.absoluteJitiPath
-    ? (...args: string[]): string => pathToFileURL(resolve(...args)) 
+    ? (...args: string[]): string => pathToFileURL(resolve(...args))
     : relative;
   const serializedJitiOptions = JSON.stringify(
     {


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

fix https://github.com/unjs/unbuild/issues/545