### PR TITLE
fix(stub): handle arbitrary module namespace identifier names (#533)

### DIFF
--- a/src/builders/rollup/stub.ts
+++ b/src/builders/rollup/stub.ts
@@ -158,7 +158,15 @@ export async function rollupStub(ctx: BuildContext): Promise<void> {
             : "",
           ...namedExports
             .filter((name) => name !== "default")
-            .map((name) => `export const ${name} = _module.${name};`),
+            .map((name) => {
+              // Check if name is a valid JS identifier
+              // Arbitrary module namespace identifiers (e.g. 'module.exports')
+              // need bracket notation for member access
+              if (/^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(name)) {
+                return `export const ${name} = _module.${name};`;
+              }
+              return `export const ${JSON.stringify(name)} = _module[${JSON.stringify(name)}];`;
+            }),
         ].join("\n"),
     );
 


### PR DESCRIPTION
Fixes #533

## Problem

Modules using arbitrary module namespace identifiers (e.g. `export const 'module.exports'`) generated invalid stub files:

```js
// Before (invalid JS)
export const module.exports = _module.module.exports;
```

## Fix

Check if the export name is a valid JS identifier. If not, use bracket notation with `JSON.stringify()` for proper escaping:

```js
// After
export const "module.exports" = _module["module.exports"];
```

This supports the `require(esm)` feature where modules export `'module.exports'` as an arbitrary identifier name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed export name generation in code stubs to properly handle non-standard identifiers using bracket notation and quotation as needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->