### PR TITLE
fix: report unused dependencies

### DIFF
--- a/src/validate.ts
+++ b/src/validate.ts
@@ -15,11 +15,6 @@ export function validateDependencies(ctx: BuildContext): void {
     unusedDependencies.delete(id);
     usedDependencies.add(id);
   }
-  if (Array.isArray(ctx.options.dependencies)) {
-    for (const id of ctx.options.dependencies) {
-      unusedDependencies.delete(id);
-    }
-  }
   for (const id of usedDependencies) {
     if (
       !arrayIncludes(ctx.options.externals, id) &&

--- a/test/validate.test.ts
+++ b/test/validate.test.ts
@@ -77,6 +77,44 @@ describe("validateDependencies", () => {
     );
   });
 
+  it("detects unused deps", () => {
+    const warnings = new Set<string>();
+
+    validateDependencies({
+      warnings,
+      pkg: { dependencies: { lodash: "^4.17.21" } },
+      buildEntries: [],
+      hooks: [] as any,
+      usedImports: new Set<string>(),
+      options: {
+        externals: [],
+        // build.ts infers this from pkg.dependencies
+        dependencies: ["lodash"],
+        peerDependencies: [],
+        devDependencies: [],
+        rootDir: ".",
+        entries: [] as BuildEntry[],
+        clean: false,
+        outDir: "dist",
+        stub: false,
+        alias: {},
+        replace: {},
+        // @ts-expect-error
+        rollup: {
+          replace: false,
+          alias: false,
+          resolve: false,
+          json: false,
+          esbuild: false,
+          commonjs: false,
+        },
+      },
+    });
+
+    expect([...warnings][0]).to.include("Potential unused dependencies found:");
+    expect([...warnings][0]).to.include("lodash");
+  });
+
   it("does not print implicit deps warning for peerDependencies", () => {
     const logs: string[] = [];
     consola.mockTypes((type) =>


### PR DESCRIPTION
Closes #524

`options.dependencies` is populated with every entry from `pkg.dependencies` (`src/build.ts`), and `validateDependencies` then deleted all of them from the `unusedDependencies` set — so the set was always empty and the "Potential unused dependencies found" warning could never fire.

Removing that block restores the check: unused dependencies (declared in `package.json` but never imported) are reported again, while genuinely-used deps are not. The implicit-dependency check is unaffected — it reads `options.dependencies` / `peerDependencies` independently.

Added a `validateDependencies` test ("detects unused deps") that fails on the old code and passes with the fix.

Verified: `pnpm lint`, `pnpm test:types`, and the full test suite (23 tests) pass.

*Written with AI assistance; I've reviewed and tested the change and will maintain it.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of unused declared dependencies.
  * Warnings now correctly identify dependencies that are configured but not used in imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->